### PR TITLE
if module realization file not exists, issue warning instead of stopping

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2304566'
+ValidationKey: '2324588'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.12.1
-Date: 2022-02-23
+Version: 0.12.2
+Date: 2022-03-03
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -117,7 +117,11 @@ update_modules_embedding <- function(modelpath=".",modulepath="modules/",include
       realizationGMSpath <- switch(version,
                                    "1" = path(fullmodulepath,module,t,ftype="gms"),
                                    "2" = path(fullmodulepath,module,t,"realization",ftype="gms"))
-      replace_in_file(realizationGMSpath,code,subject="PHASES")     
+      if(file.exists(realizationGMSpath)) {
+        replace_in_file(realizationGMSpath, code, subject = "PHASES")
+      } else {
+        warning(realizationGMSpath, " not found, this realization cannot be used!")
+      }
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.12.1**
+R package **gms**, version **0.12.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.1, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.2, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark},
   year = {2022},
-  note = {R package version 0.12.1},
+  note = {R package version 0.12.2},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
This is a suggestion to fix an issue identified running remind.

If you were working on a new module realization in remind git repository, but then switched to a different branch, sometimes the folder is not deleted because untracked input files are present. In this case, remind fails announcing in its `log.txt`:
```
Error in replace_in_file(realizationGMSpath, code, subject = "PHASES") : 
  File ./modules/45_carbonprice/NDC_linreg/realization.gms does not exist!
Calls: prepare -> update_modules_embedding -> replace_in_file
```
In this PR, I suggest to then simply issue a warning, but not let the model run fail. Of course, it will fail later if you actually tried to use the non-existing realization.