### PR TITLE
similar to PR10, allow for empty module folders

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2324588'
+ValidationKey: '2347578'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.12.2
-Date: 2022-03-03
+Version: 0.12.3
+Date: 2022-04-04
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -1,10 +1,10 @@
 #' Update Modules Embedding in GAMS code
-#' 
+#'
 #' A function that updates in the GAMS code all include commands which are
 #' related to Modules. The function automatically checks which modules exist
 #' and which files in these modules exist and creates the corresponding include
 #' commands in GAMS
-#' 
+#'
 #' @param modelpath Path to the model that should be updated (main
 #' folder).
 #' @param modulepath Module path within the model (relative to the model main
@@ -24,123 +24,119 @@
 #' @importFrom utils data
 #' @examples
 #' # copy dummymodel to temporary directory and update module embedding
-#' file.copy(system.file("dummymodel",package="gms"),tempdir(), recursive = TRUE)
+#' file.copy(system.file("dummymodel", package="gms"), tempdir(), recursive = TRUE)
 #' model   <- paste0(tempdir(),"/dummymodel")
 #' update_modules_embedding(model)
-#' 
-update_modules_embedding <- function(modelpath=".",modulepath="modules/",includefile="modules/include.gms",verbose=FALSE) {
+#'
+update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
+                                     includefile = "modules/include.gms", verbose = FALSE) {
 
-  version <- is.modularGAMS(path=modelpath,modulepath=modulepath,version=TRUE)
-  if(version==0) stop("Model does not follow modular structure.")
-  
+  version <- is.modularGAMS(path = modelpath, modulepath = modulepath, version = TRUE)
+  if (version == 0) stop("Model does not follow modular structure.")
+
   #set LC_ALL to C to avoid locale warnings
-  Sys.setlocale('LC_ALL','C') 
+  Sys.setlocale("LC_ALL", "C")
   #extract phases in the order as it is used in the code
   #this part of the functions assumes that batincludes are used exclusively
   #for module executions
-  if(file.exists(path(modelpath,"main.gms"))) {
-    code <- suppressWarnings(readLines(path(modelpath,"main.gms")))
-  } else if(file.exists(path(modelpath,"magpie.gms"))) {
-    code <- suppressWarnings(readLines(path(modelpath,"magpie.gms")))
+  if (file.exists(path(modelpath, "main.gms"))) {
+    code <- suppressWarnings(readLines(path(modelpath, "main.gms")))
+  } else if (file.exists(path(modelpath, "magpie.gms"))) {
+    code <- suppressWarnings(readLines(path(modelpath, "magpie.gms")))
   } else {
     stop("Could not find model main file. Neither main.gms nor magpie.gms do exist!")
-  }  
-  
+  }
+
   #connect whole code to one object by replacing $incude commands with
   #corresponding code (.csv, .cs2 includes and batincludes are excluded)
   repeat {
-    i <- grep("^\\$include",code)[1]
-    if(is.na(i)) break
-    tmppath <- strsplit(code[i],"\"")[[1]][2]
-    if(length(grep("\\.cs.{1,2}",tmppath))==0 && file.exists(path(modelpath,tmppath))) {
-        tmp <- suppressWarnings(readLines(path(modelpath,tmppath)))
-        code <- c(code[1:(i-1)],tmp,code[(i+1):length(code)])
+    i <- grep("^\\$include", code)[1]
+    if (is.na(i)) break
+    tmppath <- strsplit(code[i], "\"")[[1]][2]
+    if (length(grep("\\.cs.{1,2}", tmppath)) == 0 && file.exists(path(modelpath, tmppath))) {
+        tmp <- suppressWarnings(readLines(path(modelpath, tmppath)))
+        code <- c(code[1:(i - 1)], tmp, code[(i + 1):length(code)])
     } else {
-      if(length(grep("\\.cs.{1,2}",tmppath))==0 && !file.exists(path(modelpath,tmppath))) warning("Could not open include ", path(modelpath,tmppath))
+      if (length(grep("\\.cs.{1,2}", tmppath)) == 0 && ! file.exists(path(modelpath, tmppath))) {
+        warning("Could not open include ", path(modelpath, tmppath))
+      }
       code[i] <- "REMOVED"
     }
   }
-  batincludes <- code[grep("$batinclude",code,fixed=TRUE)]
-  phases <- gsub("^.*\\$batinclude .*\" ","",batincludes)
-  phases <- gsub(" ","",phases)
-  
+  batincludes <- code[grep("$batinclude", code, fixed = TRUE)]
+  phases <- gsub("^.*\\$batinclude .*\" ", "", batincludes)
+  phases <- gsub(" ", "", phases)
+
   #detect additional phases
   phasecode <- "^\\* *\\!add_phase\\!\\: *"
-  tmp <- grep(phasecode,code, value=TRUE) 
-  add_phases <- gsub(phasecode,"", tmp)
+  tmp <- grep(phasecode, code, value = TRUE)
+  add_phases <- gsub(phasecode, "", tmp)
   phases <- unique(c(phases, add_phases))
 
-  fullmodulepath <- path(modelpath,modulepath)
-  modules <- base::list.dirs(path=fullmodulepath,full.names = FALSE,recursive = FALSE)
-  
-  #create links to module main folders
-  code <- NULL
-  for(module in modules) {
-    moduleGMSpath <- switch(version,
-                         "1" = path(".",modulepath,module,module,ftype="gms"),
-                         "2" = path(".",modulepath,module,"module",ftype="gms"))
-    code <- c(code,paste("$include \"",moduleGMSpath,"\"",sep=""))
+  fullmodulepath <- path(modelpath, modulepath)
+  modules        <- getModules(fullmodulepath)[, "folder"]
+  moduleGMSpathsAll <- switch(version,
+                         "1" = path(".", modulepath, modules, modules, ftype = "gms"),
+                         "2" = path(".", modulepath, modules, "module", ftype = "gms"))
+  # excludes modules that have no gms file
+  if (! all(file.exists(moduleGMSpathsAll))) {
+    warning("Missing module gms files: ",
+      paste(moduleGMSpathsAll[! file.exists(moduleGMSpathsAll)], collapse = ", "))
   }
-  replace_in_file(path(modelpath,includefile),code,subject="MODULES")
-  
-  #set links to module types
-  for(module in modules) {
-    types <- base::list.dirs(path=path(fullmodulepath,module),full.names = FALSE,recursive = FALSE)
+  modules        <- modules[file.exists(moduleGMSpathsAll)]
+  moduleGMSpaths <- moduleGMSpathsAll[file.exists(moduleGMSpathsAll)]
+  moduleNames    <- getModules(fullmodulepath)[file.exists(moduleGMSpathsAll), "name"]
+  code <- paste("$include \"", moduleGMSpaths, "\"", sep = "")
+  replace_in_file(path(modelpath, includefile), code, subject = "MODULES")
+
+  for (m in seq_along(modules)) {
+    module <- modules[m]
+
+    #set links to module types
+    types <- base::list.dirs(path = path(fullmodulepath, module), full.names = FALSE, recursive = FALSE)
     #remove reserved module type names
-    types <- setdiff(types,getOption("gms_reserved_types"))
-    code <- NULL  
-    for(t in types) {
-       realizationGMSpath <- switch(version,
-                           "1" = path(".",modulepath,module,t,ftype="gms"),
-                           "2" = path(".",modulepath,module,t,"realization",ftype="gms"))
-        code <- c(code,paste("$Ifi \"%",substring(module,4),"%\" == \"",t,"\" $include \"",realizationGMSpath,"\"",sep="")) 
-    }
-    moduleGMSpath <- switch(version,
-                            "1" = path(fullmodulepath,module,module,ftype="gms"),
-                            "2" = path(fullmodulepath,module,"module",ftype="gms"))
-    replace_in_file(moduleGMSpath,code,subject="MODULETYPES") 
-  }
-  
-  #set links to different module phases
-  for(module in modules) {
-    types <- base::list.dirs(path=path(fullmodulepath,module),full.names = FALSE,recursive = FALSE)
-    #remove reserved module type names
-    types <- setdiff(types,getOption("gms_reserved_types"))
-    for(t in types) {
-      code <- NULL 
-      for(phase in phases) {
-        if(file.exists(paste(fullmodulepath,"/",module,"/",t,"/",phase,".gms",sep=""))) {
-          if(verbose) message(module," ",t,": ",phase," is used")
-          code <- c(code,paste("$Ifi \"%phase%\" == \"",phase,"\" $include \"",path(".",modulepath,module,t,phase,ftype="gms"),"\"",sep="")) 
-        } else if(verbose) message(module," ",t,": ",phase, "is not used")
-      }    
-      realizationGMSpath <- switch(version,
-                                   "1" = path(fullmodulepath,module,t,ftype="gms"),
-                                   "2" = path(fullmodulepath,module,t,"realization",ftype="gms"))
-      if(file.exists(realizationGMSpath)) {
-        replace_in_file(realizationGMSpath, code, subject = "PHASES")
+    types <- setdiff(types, getOption("gms_reserved_types"))
+    realizationGMSpaths <- switch(version,
+                           "1" = path(".", modulepath, module, types, ftype = "gms"),
+                           "2" = path(".", modulepath, module, types, "realization", ftype = "gms"))
+    code <- paste0("$Ifi \"%", substring(module, 4), "%\" == \"", types, "\" $include \"", realizationGMSpaths, "\"")
+    replace_in_file(moduleGMSpaths[m], code, subject = "MODULETYPES")
+
+    #set links to different module phases
+    for (ti in seq_along(types)) {
+      t <- types[ti]
+      code <- NULL
+      for (phase in phases) {
+        if (file.exists(path(".", modulepath, module, t, phase, ftype = "gms"))) {
+          if (verbose) message(module, " ", t, ": ", phase, " is used")
+          code <- c(code, paste("$Ifi \"%phase%\" == \"", phase, "\" $include \"",
+                    path(".", modulepath, module, t, phase, ftype = "gms"), "\"", sep = ""))
+        } else if (verbose) message(module, " ", t, ": ", phase, "is not used")
+      }
+      if (file.exists(realizationGMSpaths[ti])) {
+        replace_in_file(realizationGMSpaths[ti], code, subject = "PHASES")
       } else {
-        warning(realizationGMSpath, " not found, this realization cannot be used!")
+        warning(realizationGMSpaths[ti], " not found, this realization cannot be used!")
       }
     }
   }
 
   ############# ADD MODULE INFO IN SETS  ###################### START ##########################################
 
-  if(length(grep("module2realisation",readLines(path(modelpath,"core/sets.gms")))) > 0){
+  if (length(grep("module2realisation", readLines(path(modelpath, "core/sets.gms")))) > 0) {
     content <- NULL
     modification_warning <- c(
       '*** THIS CODE IS CREATED AUTOMATICALLY, DO NOT MODIFY THESE LINES DIRECTLY',
       '*** ANY DIRECT MODIFICATION WILL BE LOST AFTER NEXT MODEL START')
-    content <- c(modification_warning,'','sets')
-    content <- c(content,'','       modules "all the available modules"')
-    content <- c(content,'       /',paste0("       ",getModules(fullmodulepath)[,"name"]),'       /')
-#    content <- c(content,'','       realisations "all the active realisations"')
-#    content <- c(content,'       /',paste0("       ",unlist(unique(cfg$gms[getModules("modules/")[,"name"]]))),"       /")
-    content <- c(content,'','      module2realisation(modules,*) "mapping of modules and active realisations" /')
-    content <- c(content,paste0("       ",getModules(fullmodulepath)[,"name"]," . %",getModules(fullmodulepath)[,"name"],"%"))
-    content <- c(content,'      /',';')
-    replace_in_file('core/sets.gms',content,"MODULES",comment="***")
+    content <- c(modification_warning, '', 'sets')
+    content <- c(content, '', '       modules "all the available modules"')
+    content <- c(content, '       /', paste0("       ", moduleNames), '       /')
+#    content <- c(content, '', '       realisations "all the active realisations"')
+#    content <- c(content, '       /', paste0("       ",unlist(unique(cfg$gms[getModules("modules/")[,"name"]]))), "       /")
+    content <- c(content, '', '      module2realisation(modules,*) "mapping of modules and active realisations" /')
+    content <- c(content, paste0("       ", moduleNames, " . %", moduleNames, "%"))
+    content <- c(content, '      /', ';')
+    replace_in_file("core/sets.gms", content, "MODULES", comment = "***")
 
 
   ############# ADD MODULE INFO IN SETS  ###################### END ############################################

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.12.2**
+R package **gms**, version **0.12.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.2, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.3, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark},
   year = {2022},
-  note = {R package version 0.12.2},
+  note = {R package version 0.12.3},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/gms.Rproj
+++ b/gms.Rproj
@@ -16,3 +16,5 @@ BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes

--- a/man/update_modules_embedding.Rd
+++ b/man/update_modules_embedding.Rd
@@ -40,7 +40,7 @@ additional phase. The syntax is "* !add_phase!: <phase>", e.g. "*
 }
 \examples{
 # copy dummymodel to temporary directory and update module embedding
-file.copy(system.file("dummymodel",package="gms"),tempdir(), recursive = TRUE)
+file.copy(system.file("dummymodel", package="gms"), tempdir(), recursive = TRUE)
 model   <- paste0(tempdir(),"/dummymodel")
 update_modules_embedding(model)
 


### PR DESCRIPTION
In #10, I fixed that if a module realization does not exist, it warns instead of breaking the model.

This PR extends that to non-existing modules in folders, which can also happen if you check out a git branch where this module does not exist, but the folder is kept because of input files.

I first look for all the modules (now with getModules()) and construct the path to the corresponding gms file. If this file doesn't exist, these modules are sorted out.

I further cleaned the code. It uses less nested for-loops and more paste on vectors. Instead of running through the list of modules twice, I only walk through once.

I tested it by adding empty or non-empty module folders and realizations, it seems to work well.