### PR TITLE
in check_config, enable to add extras such as gms$c_expname

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2368896'
+ValidationKey: '2388125'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.12.4
-Date: 2022-04-22
+Version: 0.12.5
+Date: 2022-04-23
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/check_config.R
+++ b/R/check_config.R
@@ -80,7 +80,7 @@ check_config <- function(icfg, reference_file = "config/default.cfg", modulepath
     }
   }
   if (!is.null(extras)) {
-    extraSettings <- extraSettings[!(sub("\\$.*$", "", extraSettings) %in% extras)]
+    extraSettings <- extraSettings[!(sub("\\$.*$", "", extraSettings) %in% extras) & ! extraSettings %in% extras]
   }
   if (length(extraSettings) > 0) {
     warning("Settings are unknown in provided cfg (", paste("cfg", extraSettings, sep = "$", collapse = ", "),

--- a/R/setScenario.R
+++ b/R/setScenario.R
@@ -51,8 +51,8 @@ setScenario <- function(cfg,scenario,scenario_config="config/scenario_config.csv
     
     
   for (x in scenario) {
-    if(!(x %in% colnames(scenario_config))) stop("No settings for scenario ",x," found in scenario config!")
-    message("\nApply",x,"settings on config:")
+    if(!(x %in% colnames(scenario_config))) stop("No settings for scenario ", x, " found in scenario config!")
+    message("\nApply ", x, " settings on config:")
     
     # if there are no switches containing "$" all switches are interpreted as gams switches
     if (!any(grepl("\\$",rownames(scenario_config)))) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.12.4**
+R package **gms**, version **0.12.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.4, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.5, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark},
   year = {2022},
-  note = {R package version 0.12.4},
+  note = {R package version 0.12.5},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-checkConfig.R
+++ b/tests/testthat/test-checkConfig.R
@@ -1,17 +1,35 @@
 context("checkConfig test")
 
 test_that("config check fails if module switch is missing", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1))
-  expect_error(check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms")), 'Chosen realization .* does not exist for module .*')
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1))
+  expect_error(check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/", package="gms")),
+               "Chosen realization .* does not exist for module .*")
 })
 
 test_that("config check works if cfg fits to model", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="default",crazymodule="simple"))
-  x <- check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms"))
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1,
+              fancymodule = "default", crazymodule = "simple"))
+  x <- check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/", package = "gms"))
   expect_identical(x,cfg)
 })
 
 test_that("config check fails if module realization does not exist", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="hallo",crazymodule="simple"))
-  expect_error(check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms")),"Chosen realization \"hallo\" does not exist for module \"fancymodule\"")
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1,
+              fancymodule = "hallo", crazymodule = "simple"))
+  expect_error(check_config(cfg, reference_file = cfg,
+               modulepath = system.file("dummymodel/modules/", package = "gms")),
+               "Chosen realization \"hallo\" does not exist for module \"fancymodule\"")
+})
+
+test_that("config check accepts extras as argument", {
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1,
+              fancymodule = "default", crazymodule = "simple"))
+  cfgextra <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "default",
+                   crazymodule = "simple", extra1 = TRUE), extra2 = TRUE)
+  expect_warning(check_config(cfgextra, reference_file = cfg,
+                 modulepath = system.file("dummymodel/modules/", package = "gms")),
+                 "Settings are unknown in provided cfg")
+  expect_silent(x <- check_config(cfgextra, reference_file = cfg,
+                    modulepath = system.file("dummymodel/modules/", package="gms"),
+                    extras = c("gms$extra1", "extra2")))
 })


### PR DESCRIPTION
`check_config` has the option to add `extras`, a vector with additional arguments that are allowed in the cfg. Unfortunately, it was impossible to specify something like `gms$addsomething` as extra, because the checking routing forgets everything after the `$`, see below, `cfg$gms$addsomething` cannot be catched, only if `gms` is added to `extras`, resulting in a not very specific exclusion.
```
cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "default", crazymodule = "simple"))
cfgextra <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "default", crazymodule = "simple", extra1 = TRUE), extra2 = TRUE)
check_config(cfgextra, reference_file = cfg, modulepath = system.file("dummymodel/modules/", package="gms"), extras = c("gms$extra1", "extra2"))
```
This should not throw a warning, but does. I added two tests to `test_that` that show that the revised version throws warnings as appropriate.

This PR enables to add further values [in `remind/scripts/start/prepare_and_run.R`](https://github.com/remindmodel/remind/blob/develop/scripts/start/prepare_and_run.R#L247) that continues to throw warnings, particularly for coupled and restarted runs.