### PR TITLE
singleGAMSfile: add option to also embed executed R scripts

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2388125'
+ValidationKey: '2484170'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.12.5
-Date: 2022-04-23
+Version: 0.13.0
+Date: 2022-04-27
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/singleGAMSfile.R
+++ b/R/singleGAMSfile.R
@@ -110,25 +110,25 @@ singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "ful
       if (is.na(i)) break
 
       # extract R script file name
-      RFileName <- sub("^Execute\\s+\"Rscript (.*)\";", "\\1", code[i], ignore.case = TRUE)
+      rFileName <- sub("^Execute\\s+\"Rscript (.*)\";", "\\1", code[i], ignore.case = TRUE)
       # check if R script is included in core or a module
-      if ((substr(RFileName, 0, 4) == "core" | substr(RFileName, 0, 7) == "modules") & file.exists(RFileName)) {
+      if ((substr(rFileName, 0, 4) == "core" | substr(rFileName, 0, 7) == "modules") & file.exists(rFileName)) {
         # embed the R script using $onecho and $offecho
         # we also replace the "Execute" call so that it finds the script at the position it is written by $onecho
-        BaseRFileName <- basename(RFileName)
-        RFileContent <- suppressWarnings(readLines(RFileName))
+        baseRFileName <- basename(rFileName)
+        rFileContent <- suppressWarnings(readLines(rFileName))
         if (i < length(code)) {
           remainder <- code[(i + 1):length(code)]
         } else {
           remainder <- NULL
         }
         code <- c(code[1:(i - 1)],
-                  paste0("$onecho > ", BaseRFileName),
-                  RFileContent,
+                  paste0("$onecho > ", baseRFileName),
+                  rFileContent,
                   "$offecho",
-                  paste0("Execute \"Rscript ", BaseRFileName, "\";"),
+                  paste0("Execute \"Rscript ", baseRFileName, "\";"),
                   remainder)
-        i <- i + length(RFileContent) + 2
+        i <- i + length(rFileContent) + 2
       }
       else {
         # R script wasn't found at the expected location, can't be embedded

--- a/R/singleGAMSfile.R
+++ b/R/singleGAMSfile.R
@@ -115,7 +115,7 @@ singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "ful
       if ((substr(rFileName, 0, 4) == "core" | substr(rFileName, 0, 7) == "modules") & file.exists(rFileName)) {
         # embed the R script using $onecho and $offecho
         # we also replace the "Execute" call so that it finds the script at the position it is written by $onecho
-        baseRFileName <- basename(rFileName)
+        newRFileName <- gsub("\\", "_", gsub("/", "_", rFileName, fixed = TRUE), fixed = TRUE)
         rFileContent <- suppressWarnings(readLines(rFileName))
         if (i < length(code)) {
           remainder <- code[(i + 1):length(code)]
@@ -123,10 +123,10 @@ singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "ful
           remainder <- NULL
         }
         code <- c(code[1:(i - 1)],
-                  paste0("$onecho > ", baseRFileName),
+                  paste0("$onecho > ", newRFileName),
                   rFileContent,
                   "$offecho",
-                  paste0("Execute \"Rscript ", baseRFileName, "\";"),
+                  paste0("Execute \"Rscript ", newRFileName, "\";"),
                   remainder)
         i <- i + length(rFileContent) + 2
       }

--- a/R/singleGAMSfile.R
+++ b/R/singleGAMSfile.R
@@ -115,7 +115,7 @@ singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "ful
       if ((substr(rFileName, 0, 4) == "core" | substr(rFileName, 0, 7) == "modules") & file.exists(rFileName)) {
         # embed the R script using $onecho and $offecho
         # we also replace the "Execute" call so that it finds the script at the position it is written by $onecho
-        newRFileName <- gsub("\\", "_", gsub("/", "_", rFileName, fixed = TRUE), fixed = TRUE)
+        newRFileName <- gsub("[\\/]", "_", rFileName)
         rFileContent <- suppressWarnings(readLines(rFileName))
         if (i < length(code)) {
           remainder <- code[(i + 1):length(code)]

--- a/R/singleGAMSfile.R
+++ b/R/singleGAMSfile.R
@@ -1,12 +1,14 @@
 #' Merge GAMS code into single file
 #'
 #' This function merges GAMS code which is distributed over severals files into
-#' a single GAMS file.
+#' a single GAMS file. Optionally, it also embeds R scripts into the single GAMS
+#' file
 #'
 #'
 #' @param modelpath The path where the model is stored
 #' @param mainfile The path to the main gams file (relative to the model path)
 #' @param output Name of the single output GAMS file.
+#' @param embedRScripts If TRUE, R scripts called by GAMS via Execute are also embedded. Default FALSE
 #' @author Jan Philipp Dietrich, Anastasis Giannousakis
 #' @export
 #' @importFrom utils tail
@@ -17,7 +19,7 @@
 #' singlefile <- paste0(tempdir(), "/full.gms")
 #' singleGAMSfile(modelpath = model, output = singlefile)
 #'
-singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "full.gms") {
+singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "full.gms", embedRScripts = FALSE) {
 
   .insertIncludeFile <- function(code, i, path) {
     path <- gsub(";", "", path)
@@ -35,10 +37,7 @@ singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "ful
     return(code)
   }
 
-  withr::with_dir(modelpath, {
-    # set LC_ALL to C to avoid locale warnings
-    Sys.setlocale("LC_ALL", "C")
-
+  .mergeGamsFiles <- function(mainfile) {
     code <- readLines(mainfile, warn = FALSE)
     code <- c("* #### CODE MERGED WITH FUNCTION gms::singleGAMSfile ####", "", code)
 
@@ -100,7 +99,53 @@ singleGAMSfile <- function(modelpath = ".", mainfile = "main.gms", output = "ful
         warning("Catched a command which could not be translated (", code[i], ")")
       }
     }
-  })  # end withr::with_dir(modelpath)
+    return(code)
+  }
+
+  .embedRScripts <- function(code) {
+    i <- 1
+    repeat {
+      # find first 'Execute "Rscript' which was not handled yet
+      i <- grep("^Execute\\s+\"Rscript", tail(code, -i), ignore.case = TRUE)[1] + i
+      if (is.na(i)) break
+
+      # extract R script file name
+      RFileName <- sub("^Execute\\s+\"Rscript (.*)\";", "\\1", code[i], ignore.case = TRUE)
+      # check if R script is included in core or a module
+      if ((substr(RFileName, 0, 4) == "core" | substr(RFileName, 0, 7) == "modules") & file.exists(RFileName)) {
+        # embed the R script using $onecho and $offecho
+        # we also replace the "Execute" call so that it finds the script at the position it is written by $onecho
+        BaseRFileName <- basename(RFileName)
+        RFileContent <- suppressWarnings(readLines(RFileName))
+        if (i < length(code)) {
+          remainder <- code[(i + 1):length(code)]
+        } else {
+          remainder <- NULL
+        }
+        code <- c(code[1:(i - 1)],
+                  paste0("$onecho > ", BaseRFileName),
+                  RFileContent,
+                  "$offecho",
+                  paste0("Execute \"Rscript ", BaseRFileName, "\";"),
+                  remainder)
+        i <- i + length(RFileContent) + 2
+      }
+      else {
+        # R script wasn't found at the expected location, can't be embedded
+        i <- i + 1
+      }
+    }
+    return(code)
+  }
+
+  withr::with_dir(modelpath, {
+    # set LC_ALL to C to avoid locale warnings
+    Sys.setlocale("LC_ALL", "C")
+    code <- .mergeGamsFiles(mainfile)
+    if (embedRScripts) {
+      code <- .embedRScripts(code)
+    }
+  })
 
   writeLines(code, output)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.12.5**
+R package **gms**, version **0.13.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.12.5, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.13.0, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark},
   year = {2022},
-  note = {R package version 0.12.5},
+  note = {R package version 0.13.0},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/inst/dummymodel/main.gms
+++ b/inst/dummymodel/main.gms
@@ -9,10 +9,12 @@ $title dummymodel
 *' by goxygen, but has not content and cannot be solved with GAMS. It can serve as 
 *' a template to build a modular GAMS model from scratch.
 *'
-*' The dummy model consists of two modules [01_fancymodule] and [02_crazymodule].
+*' The dummy model consists of three modules [01_fancymodule], [02_crazymodule],
+*' and [03_Rmodule].
 
 $setglobal fancymodule  default
 $setglobal crazymodule  simple
+$setglobal Rmodule  withr
 
 $include "./core/sets.gms"
 $include "./core/core.gms"

--- a/inst/dummymodel/modules/03_Rmodule/module.gms
+++ b/inst/dummymodel/modules/03_Rmodule/module.gms
@@ -1,0 +1,9 @@
+*' @title Module which uses R
+
+*' @description This module uses an R script!
+
+*' @authors Bruce Wayne, Max Mustermann
+
+*###################### R SECTION START (MODULETYPES) ##########################
+$Ifi "%Rmodule%" == "withr" $include "./modules/03_Rmodule/withr/realization.gms"
+*###################### R SECTION END (MODULETYPES) ############################

--- a/inst/dummymodel/modules/03_Rmodule/withr/calculations.gms
+++ b/inst/dummymodel/modules/03_Rmodule/withr/calculations.gms
@@ -1,0 +1,3 @@
+*' @code Let's add running an R script
+
+Execute "Rscript run_calculations.R";

--- a/inst/dummymodel/modules/03_Rmodule/withr/calculations.gms
+++ b/inst/dummymodel/modules/03_Rmodule/withr/calculations.gms
@@ -1,3 +1,3 @@
 *' @code Let's add running an R script
 
-Execute "Rscript run_calculations.R";
+Execute "Rscript modules/03_Rmodule/withr/run_calculations.R";

--- a/inst/dummymodel/modules/03_Rmodule/withr/calculations.gms
+++ b/inst/dummymodel/modules/03_Rmodule/withr/calculations.gms
@@ -1,3 +1,4 @@
-*' @code Let's add running an R script
+*' @code Let's add running an R script, twice
 
+Execute "Rscript modules/03_Rmodule/withr/run_calculations.R";
 Execute "Rscript modules/03_Rmodule/withr/run_calculations.R";

--- a/inst/dummymodel/modules/03_Rmodule/withr/realization.gms
+++ b/inst/dummymodel/modules/03_Rmodule/withr/realization.gms
@@ -1,0 +1,8 @@
+
+*' @description This realization uses R!
+
+*' @limitations It is not really working as it is just an example.
+
+*####################### R SECTION START (PHASES) ##############################
+$Ifi "%phase%" == "calculations" $include "./modules/03_Rmodule/withr/calculations.gms"
+*######################## R SECTION END (PHASES) ###############################

--- a/inst/dummymodel/modules/03_Rmodule/withr/run_calculations.R
+++ b/inst/dummymodel/modules/03_Rmodule/withr/run_calculations.R
@@ -1,0 +1,2 @@
+# a very important calculation, which can not possibly be done in GAMS
+1 + 2

--- a/inst/dummymodel/modules/include.gms
+++ b/inst/dummymodel/modules/include.gms
@@ -3,5 +3,6 @@ $onrecurse
 *######################## R SECTION START (MODULES) ############################
 $include "./modules/01_fancymodule/module.gms"
 $include "./modules/02_crazymodule/module.gms"
+$include "./modules/03_Rmodule/module.gms"
 *######################## R SECTION END (MODULES) ##############################
 $offrecurse

--- a/inst/extdata/full.gms
+++ b/inst/extdata/full.gms
@@ -11,10 +11,12 @@ $title dummymodel
 *' by goxygen, but has not content and cannot be solved with GAMS. It can serve as 
 *' a template to build a modular GAMS model from scratch.
 *'
-*' The dummy model consists of two modules [01_fancymodule] and [02_crazymodule].
+*' The dummy model consists of three modules [01_fancymodule], [02_crazymodule],
+*' and [03_Rmodule].
 
 $setglobal fancymodule  default
 $setglobal crazymodule  simple
+$setglobal Rmodule  withr
 
 *$include "./core/sets.gms" DONE!
 sets
@@ -123,6 +125,27 @@ equations
 *' @code Let's add some standard code
 
 display vm_exchange.l;
+*######################## R SECTION END (PHASES) ###############################
+*###################### R SECTION END (MODULETYPES) ############################
+*$include "./modules/03_Rmodule/module.gms" DONE!
+*' @title Module which uses R
+
+*' @description This module uses an R script!
+
+*' @authors Bruce Wayne, Max Mustermann
+
+*###################### R SECTION START (MODULETYPES) ##########################
+*$Ifi "%Rmodule%" == "withr" $include "./modules/03_Rmodule/withr/realization.gms" DONE!
+
+*' @description This realization uses R!
+
+*' @limitations It is not really working as it is just an example.
+
+*####################### R SECTION START (PHASES) ##############################
+*$Ifi "%phase%" == "calculations" $include "./modules/03_Rmodule/withr/calculations.gms" DONE!
+*' @code Let's add running an R script
+
+Execute "Rscript run_calculations.R";
 *######################## R SECTION END (PHASES) ###############################
 *###################### R SECTION END (MODULETYPES) ############################
 *######################## R SECTION END (MODULES) ##############################

--- a/inst/extdata/full.gms
+++ b/inst/extdata/full.gms
@@ -145,6 +145,10 @@ display vm_exchange.l;
 *$Ifi "%phase%" == "calculations" $include "./modules/03_Rmodule/withr/calculations.gms" DONE!
 *' @code Let's add running an R script
 
+$onecho > run_calculations.R;
+# a very important calculation, which can not possibly be done in GAMS
+1 + 2
+$offecho
 Execute "Rscript run_calculations.R";
 *######################## R SECTION END (PHASES) ###############################
 *###################### R SECTION END (MODULETYPES) ############################

--- a/inst/extdata/full_embed.gms
+++ b/inst/extdata/full_embed.gms
@@ -145,16 +145,16 @@ display vm_exchange.l;
 *$Ifi "%phase%" == "calculations" $include "./modules/03_Rmodule/withr/calculations.gms" DONE!
 *' @code Let's add running an R script, twice
 
-$onecho > run_calculations.R
+$onecho > modules_03_Rmodule_withr_run_calculations.R
 # a very important calculation, which can not possibly be done in GAMS
 1 + 2
 $offecho
-Execute "Rscript run_calculations.R";
-$onecho > run_calculations.R
+Execute "Rscript modules_03_Rmodule_withr_run_calculations.R";
+$onecho > modules_03_Rmodule_withr_run_calculations.R
 # a very important calculation, which can not possibly be done in GAMS
 1 + 2
 $offecho
-Execute "Rscript run_calculations.R";
+Execute "Rscript modules_03_Rmodule_withr_run_calculations.R";
 *######################## R SECTION END (PHASES) ###############################
 *###################### R SECTION END (MODULETYPES) ############################
 *######################## R SECTION END (MODULES) ##############################

--- a/inst/extdata/full_embed.gms
+++ b/inst/extdata/full_embed.gms
@@ -145,8 +145,16 @@ display vm_exchange.l;
 *$Ifi "%phase%" == "calculations" $include "./modules/03_Rmodule/withr/calculations.gms" DONE!
 *' @code Let's add running an R script, twice
 
-Execute "Rscript modules/03_Rmodule/withr/run_calculations.R";
-Execute "Rscript modules/03_Rmodule/withr/run_calculations.R";
+$onecho > run_calculations.R
+# a very important calculation, which can not possibly be done in GAMS
+1 + 2
+$offecho
+Execute "Rscript run_calculations.R";
+$onecho > run_calculations.R
+# a very important calculation, which can not possibly be done in GAMS
+1 + 2
+$offecho
+Execute "Rscript run_calculations.R";
 *######################## R SECTION END (PHASES) ###############################
 *###################### R SECTION END (MODULETYPES) ############################
 *######################## R SECTION END (MODULES) ##############################

--- a/man/singleGAMSfile.Rd
+++ b/man/singleGAMSfile.Rd
@@ -4,7 +4,12 @@
 \alias{singleGAMSfile}
 \title{Merge GAMS code into single file}
 \usage{
-singleGAMSfile(modelpath = ".", mainfile = "main.gms", output = "full.gms")
+singleGAMSfile(
+  modelpath = ".",
+  mainfile = "main.gms",
+  output = "full.gms",
+  embedRScripts = FALSE
+)
 }
 \arguments{
 \item{modelpath}{The path where the model is stored}
@@ -12,10 +17,13 @@ singleGAMSfile(modelpath = ".", mainfile = "main.gms", output = "full.gms")
 \item{mainfile}{The path to the main gams file (relative to the model path)}
 
 \item{output}{Name of the single output GAMS file.}
+
+\item{embedRScripts}{If TRUE, R scripts called by GAMS via Execute are also embedded. Default FALSE}
 }
 \description{
 This function merges GAMS code which is distributed over severals files into
-a single GAMS file.
+a single GAMS file. Optionally, it also embeds R scripts into the single GAMS
+file
 }
 \examples{
 # copy dummymodel create single gms file out of it

--- a/tests/testthat/test-checkConfig.R
+++ b/tests/testthat/test-checkConfig.R
@@ -1,17 +1,23 @@
 context("checkConfig test")
 
 test_that("config check fails if module switch is missing", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1))
-  expect_error(check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms")), 'Chosen realization .* does not exist for module .*')
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1))
+  expect_error(check_config(cfg, reference_file = cfg,
+                            modulepath = system.file("dummymodel/modules/", package = "gms")),
+               "Chosen realization .* does not exist for module .*")
 })
 
 test_that("config check works if cfg fits to model", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="default",crazymodule="simple",Rmodule="withr"))
-  x <- check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms"))
-  expect_identical(x,cfg)
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "default",
+                                            crazymodule = "simple", Rmodule = "withr"))
+  x <- check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/", package = "gms"))
+  expect_identical(x, cfg)
 })
 
 test_that("config check fails if module realization does not exist", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="hallo",crazymodule="simple",Rmodule="withr"))
-  expect_error(check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms")),"Chosen realization \"hallo\" does not exist for module \"fancymodule\"")
+  cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "hallo", crazymodule = "simple",
+                                            Rmodule = "withr"))
+  expect_error(check_config(cfg, reference_file = cfg,
+                            modulepath = system.file("dummymodel/modules/", package = "gms")),
+               "Chosen realization \"hallo\" does not exist for module \"fancymodule\"")
 })

--- a/tests/testthat/test-checkConfig.R
+++ b/tests/testthat/test-checkConfig.R
@@ -6,12 +6,12 @@ test_that("config check fails if module switch is missing", {
 })
 
 test_that("config check works if cfg fits to model", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="default",crazymodule="simple"))
+  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="default",crazymodule="simple",Rmodule="withr"))
   x <- check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms"))
   expect_identical(x,cfg)
 })
 
 test_that("config check fails if module realization does not exist", {
-  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="hallo",crazymodule="simple"))
+  cfg <- list(title = "default", gms = list(switch1=TRUE, switch2=1, fancymodule="hallo",crazymodule="simple",Rmodule="withr"))
   expect_error(check_config(cfg, reference_file = cfg, modulepath = system.file("dummymodel/modules/",package="gms")),"Chosen realization \"hallo\" does not exist for module \"fancymodule\"")
 })

--- a/tests/testthat/test-checkConfig.R
+++ b/tests/testthat/test-checkConfig.R
@@ -24,9 +24,9 @@ test_that("config check fails if module realization does not exist", {
 
 test_that("config check accepts extras as argument", {
   cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1,
-              fancymodule = "default", crazymodule = "simple"))
+              fancymodule = "default", crazymodule = "simple", Rmodule="withr"))
   cfgextra <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "default",
-                   crazymodule = "simple", extra1 = TRUE), extra2 = TRUE)
+                   crazymodule = "simple", Rmodule="withr", extra1 = TRUE), extra2 = TRUE)
   expect_warning(check_config(cfgextra, reference_file = cfg,
                  modulepath = system.file("dummymodel/modules/", package = "gms")),
                  "Settings are unknown in provided cfg")

--- a/tests/testthat/test-checkConfig.R
+++ b/tests/testthat/test-checkConfig.R
@@ -24,13 +24,13 @@ test_that("config check fails if module realization does not exist", {
 
 test_that("config check accepts extras as argument", {
   cfg <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1,
-              fancymodule = "default", crazymodule = "simple", Rmodule="withr"))
+              fancymodule = "default", crazymodule = "simple", Rmodule = "withr"))
   cfgextra <- list(title = "default", gms = list(switch1 = TRUE, switch2 = 1, fancymodule = "default",
-                   crazymodule = "simple", Rmodule="withr", extra1 = TRUE), extra2 = TRUE)
+                   crazymodule = "simple", Rmodule = "withr", extra1 = TRUE), extra2 = TRUE)
   expect_warning(check_config(cfgextra, reference_file = cfg,
                  modulepath = system.file("dummymodel/modules/", package = "gms")),
                  "Settings are unknown in provided cfg")
   expect_silent(x <- check_config(cfgextra, reference_file = cfg,
-                    modulepath = system.file("dummymodel/modules/", package="gms"),
+                    modulepath = system.file("dummymodel/modules/", package = "gms"),
                     extras = c("gms$extra1", "extra2")))
 })

--- a/tests/testthat/test-singleGAMSfile.R
+++ b/tests/testthat/test-singleGAMSfile.R
@@ -5,3 +5,9 @@ test_that("GAMS file merge is working", {
   expect_silent(singleGAMSfile(system.file("dummymodel",package="gms"),output = tmpfile))
   expect_identical(readLines(tmpfile), readLines(system.file("extdata/full.gms",package="gms")))
 })
+
+test_that("Embedding R scripts into GAMS files is working", {
+  tmpfile <- tempfile()
+  expect_silent(singleGAMSfile(system.file("dummymodel",package="gms"),output = tmpfile, embedRScripts = TRUE))
+  expect_identical(readLines(tmpfile), readLines(system.file("extdata/full_embed.gms",package="gms")))
+})

--- a/tests/testthat/test-singleGAMSfile.R
+++ b/tests/testthat/test-singleGAMSfile.R
@@ -2,12 +2,12 @@ context("singleGAMSfile test")
 
 test_that("GAMS file merge is working", {
   tmpfile <- tempfile()
-  expect_silent(singleGAMSfile(system.file("dummymodel",package="gms"),output = tmpfile))
-  expect_identical(readLines(tmpfile), readLines(system.file("extdata/full.gms",package="gms")))
+  expect_silent(singleGAMSfile(system.file("dummymodel", package = "gms"), output = tmpfile))
+  expect_identical(readLines(tmpfile), readLines(system.file("extdata/full.gms", package = "gms")))
 })
 
 test_that("Embedding R scripts into GAMS files is working", {
   tmpfile <- tempfile()
-  expect_silent(singleGAMSfile(system.file("dummymodel",package="gms"),output = tmpfile, embedRScripts = TRUE))
-  expect_identical(readLines(tmpfile), readLines(system.file("extdata/full_embed.gms",package="gms")))
+  expect_silent(singleGAMSfile(system.file("dummymodel", package = "gms"), output = tmpfile, embedRScripts = TRUE))
+  expect_identical(readLines(tmpfile), readLines(system.file("extdata/full_embed.gms", package = "gms")))
 })


### PR DESCRIPTION
Hi,

This adds an option to singleGAMSfile to also embed R scripts which are executed using
```gams
Execute "Rscript path/to/script.R";
```
in GAMS. This will be transformed into
```gams
$onecho > script.R
<content of script.R>
$offecho
Execute "Rscript script.R";
```

The transformation is not enabled by default but gated behind a boolean flag argument so that users can choose themselves to enable the transformation.

Cheers,

Mika