### PR TITLE
Fix getLine() in RStudio

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3109104'
+ValidationKey: '3131719'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -11,7 +11,7 @@ on:
 env:
   USE_BSPM: "true"
   _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen")'
+  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc")'
 
 jobs:
   lucode2-check:
@@ -56,6 +56,11 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v1
 
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
       - name: Cache R libraries
         uses: pat-s/always-upload-cache@v3
         with:
@@ -70,9 +75,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./run.sh install_aptget libhdf5-dev
+          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
           ./run.sh install_all
           ./run.sh install_r lucode2 covr rstudioapi
+
+      - name: Install python dependencies if applicable
+        run: |
+          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
+          [ -f requirements.txt ] && pip install -r requirements.txt || true
 
       - name: Remove bspm integration # to get rid of error when running install.packages
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,22 @@ repos:
     hooks:
     -   id: check-case-conflict
     -   id: check-json
-    -   id: check-yaml
     -   id: check-merge-conflict
+    -   id: check-yaml
     -   id: fix-byte-order-marker
+    -   id: check-added-large-files
+        args: ['--maxkb=100']
+    -   id: mixed-line-ending
+
+-   repo: https://github.com/lorenzwalthert/precommit
+    rev: v0.3.2
+    hooks:
+    -   id: parsable-R
+    -   id: deps-in-desc
+        args: [--allow_private_imports]
+    -   id: no-browser-statement
+    -   id: no-debug-statement
+    -   id: readme-rmd-rendered
+    -   id: use-tidy-description
 ci:
     autoupdate_schedule: quarterly

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.16.2
-Date: 2022-07-19
+Version: 0.16.3
+Date: 2022-08-09
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),
@@ -34,4 +34,4 @@ BugReports: https://github.com/pik-piam/gms/issues
 License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/getLine.R
+++ b/R/getLine.R
@@ -8,5 +8,8 @@
 #' @importFrom withr local_connection
 #' @export
 getLine <- function() {
+  if (interactive()) {
+    return(readline())
+  }
   return(readLines(withr::local_connection(file("stdin")), n = 1))
 }

--- a/R/getLine.R
+++ b/R/getLine.R
@@ -9,6 +9,7 @@
 #' @export
 getLine <- function() {
   if (interactive()) {
+    # needed for e.g. RStudio and R in jupyter
     return(readline())
   }
   return(readLines(withr::local_connection(file("stdin")), n = 1))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.16.2**
+R package **gms**, version **0.16.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.16.2, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.16.3, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark},
   year = {2022},
-  note = {R package version 0.16.2},
+  note = {R package version 0.16.3},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
When we moved `getLine` from all over our codebase to gms, we also deleted the `if (interactive)` block because it didn't seem like we needed it, everything was working interactively nicely when using `R` or `radian`. However, it turns out jupyter and RStudio do even more funky stuff with stdin, and it doesn't work. So, fall back to `readline()` in interactive use again. `readline()` is so frequently used, it should work in all fancy interactive environments.

Fixes: #31 