### PR TITLE
Fix name clash and refactor codeCheck

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3467160'
+ValidationKey: '3488775'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -54,7 +54,8 @@ jobs:
           ' "$NO_BINARY_INSTALL_R_PACKAGES" | sudo tee --append /etc/R/Rprofile.site >/dev/null
           cat /etc/R/Rprofile.site
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
@@ -62,6 +63,7 @@ jobs:
           python-version: 3.9
 
       - name: Cache R libraries
+        if: ${{ !env.ACT }} # skip when running locally via nektos/act
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9003
+    rev: v0.3.2.9001
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.18.0
-Date: 2022-09-27
+Version: 0.18.1
+Date: 2022-10-10
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -132,9 +132,9 @@ codeCheck <- function(path=".",modulepath="modules", core_files = c("core/*.gms"
 
   #are any non-interface core variables used in other places than the core?
   wrong <- names(ap$type)[ap$type == "" & (rowSums(ap$appearance) > 1 | !ap$appearance[, "core"])]
-  for (w in wrong) {
+  for (wrong_item in wrong) {
     mod <- unique(sub("\\.[^\\.]*$", "", dimnames(ap$appearance)[[2]][ap$appearance[w,]>0]))
-    w <- .warning(w, " appears in \"", paste(mod, collapse = "\", \""),"\" but its name suggests that it is core only!",w=w)
+    w <- .warning(wrong_item, " appears in \"", paste(mod, collapse = "\", \""),"\" but its name suggests that it is core only!",w=w)
   }
 
   #are any module variables used somewhere else?

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -28,291 +28,450 @@
 #' @export
 #' @seealso \code{\link{codeExtract}},\code{\link{readDeclarations}}
 #' @importFrom utils write.table read.csv
+#' @importFrom stringr str_pad
 #' @examples
 #' # check code consistency of dummy model
-#' codeCheck(system.file("dummymodel",package="gms"))
+#' codeCheck(system.file("dummymodel", package = "gms"))
 #'
+codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*.gms", "main.gms"),
+                      debug = FALSE, interactive = FALSE, test_switches = TRUE, strict = FALSE, details = FALSE) {
 
-codeCheck <- function(path=".",modulepath="modules", core_files = c("core/*.gms","main.gms"), debug=FALSE, interactive=FALSE, test_switches=TRUE, strict=FALSE, details=FALSE) {
-
-  .check_input_files <- function(w,path=".", modulepath="modules") {
-    inputgms <- Sys.glob(paste0(path,"/",modulepath,"/*/*/input.gms"))
-    for(gms in inputgms) {
-      #read $include lines
-      includes <- grep("\\$include",readLines(gms,warn = FALSE),value = TRUE)
-      realization <- gsub("^.*/[0-9]{2}_[^/]*/(.*)/[^\\.]*\\..*$", "\\1",gms)
-      inputfolders <- gsub("^.*/[0-9]{2}_[^/]*/(.*)/[^\\.]*\\..*$", "\\1",includes)
-      inputfolders <- gsub("^.*\\./(.*)/[^\\.]*\\..*$", "\\1",inputfolders)
-      tmp <- gsub(paste0("^",realization,"/"),"",inputfolders)
-      folderok <- grepl("^input",tmp)
-      #folderok <- (inputfolders %in% c("input",paste0(realization,"/input")))
-      if(any(!folderok)) {
-        for(f in which(!folderok)) w <- .warning("Input file in ",sub(paste0(path,"/",modulepath),"",gms)," read from illegal location (",includes[f],"). Allowed folders are <module>/input or <module>/<realization>/input.",w=w)
+  .checkInputFiles <- function(w, path = ".", modulepath = "modules") {
+    inputgms <- Sys.glob(paste0(path, "/", modulepath, "/*/*/input.gms"))
+    for (gms in inputgms) {
+      # read $include lines
+      includes <- grep("\\$include", readLines(gms, warn = FALSE), value = TRUE)
+      realization <- gsub("^.*/[0-9]{2}_[^/]*/(.*)/[^\\.]*\\..*$", "\\1", gms)
+      inputfolders <- gsub("^.*/[0-9]{2}_[^/]*/(.*)/[^\\.]*\\..*$", "\\1", includes)
+      inputfolders <- gsub("^.*\\./(.*)/[^\\.]*\\..*$", "\\1", inputfolders)
+      tmp <- gsub(paste0("^", realization, "/"), "", inputfolders)
+      folderok <- grepl("^input", tmp)
+      if (any(!folderok)) {
+        for (f in which(!folderok)) {
+           w <- .warning("Input file in ",
+                         sub(paste0(path, "/", modulepath), "", gms),
+                         " read from illegal location (",
+                         includes[f],
+                         "). Allowed folders are <module>/input or <module>/<realization>/input.",
+                         w = w)
+        }
       }
     }
     return(w)
   }
 
-  .choose_option <- function(options,...) {
-    title <- paste0(...)
-    message("\n\n",title)
-    message(paste(1: length(options), options, sep=": ", collapse="\n"))
-    message("\nNumber: ")
-    identifier <- getLine()
-    identifier <- as.numeric(strsplit(identifier,",")[[1]])
-    if (any(!(identifier %in% 1:length(options)))) stop("This choice (",identifier,") is not possible. Please type in a number between 1 and ",length(options))
-    return(options[identifier])
+  .collectData <- function(path, modulepath, coreFiles, modulesInfo) {
+    # returns a named list containing the code (without comments) and the corresponding declarations,
+    # each divided into a core part and a part with the code/declarations of all modules.
+    # Additionally, the named list also contains the not_used information from the modules.
+    allFiles <- list.files(path = path, pattern = "\\.gms$", recursive = TRUE)
+    moduleFiles <-  paste0(path, "/", grep(paste("^", modulepath, sep = ""), allFiles, value = TRUE))
+    coreFiles <- Sys.glob(paste0(path, "/", coreFiles))
+    core <- codeExtract(coreFiles, "core")
+    modules <- list()
+    for (i in seq_len(dim(modulesInfo)[1])) {
+        m <- modulesInfo[i, ]
+        for (j in strsplit(m["realizations"], ",")[[1]]) {
+            tmp <- codeExtract(grep(paste0(m["folder"], "/", j, "/"), moduleFiles, value = TRUE),
+                               name = paste(m["name"], j, sep = "."))
+            modules$code <- c(modules$code, tmp$code)
+            modules$declarations <- rbind(modules$declarations, tmp$declarations)
+            notUsedPath <- paste0(path, "/", modulepath, "/", m["folder"], "/", j, "/not_used.txt")
+            if (file.exists(notUsedPath)) {
+                tmp <- as.matrix(suppressWarnings(read.csv(notUsedPath, as.is = TRUE, comment.char = "#")))
+                dimnames(tmp)[[1]] <- rep(paste(m["name"], j, sep = "."), dim(tmp)[1])
+                modules$not_used <- rbind(modules$not_used, tmp)
+            }
+        }
+    }
+
+    gams <- list(code = c(core$code, modules$code),
+                 declarations = rbind(core$declarations, modules$declarations),
+                 not_used = modules$not_used)
+    return(gams)
+  }
+
+  .checkNamingConventions <- function(gams, w) {
+    # Do all declarations follow the naming conventions? (see the coding etiquette at
+    # https://github.com/magpiemodel/tutorials/blob/master/4_GAMScodeStructure.md#23-coding-etiquette-variable-and-parameter-naming
+    # for further information)
+    # Remove objects which do not follow the naming conventions from the declarations set as
+    # they would otherwise cause problems in what follows
+    tmp <- grep("^[qvsfipoxcm]{1}[cqv]?(m|[0-9]{2}|)_", gams$declarations[, "names"], invert = TRUE)
+    tmp <- tmp[gams$declarations[tmp, "type"] != "set"] # remove set entries from analysis
+    if (length(tmp) > 0) {
+      declarationNames <- gams$declarations[tmp, "names"]
+      declarationDescription <- gams$declarations[tmp, "description"]
+      gams$declarations <- gams$declarations[-tmp, ]
+      for (i in seq_along(declarationNames)) {
+        w <- .warning(names(declarationNames)[i],
+                      ": \"",
+                      declarationNames[i],
+                      "\" does not follow the given naming conventions (description = \"",
+                      declarationDescription[i],
+                      "\")!",
+                      w = w)
+        }
+      }
+    if (!is.null(gams$not_used)) {
+      tmp <- grep("_", gams$not_used[, "name"], invert = TRUE)
+      if (length(tmp) > 0) {
+        declarationNames <- gams$not_used[tmp, "name"]
+        names(declarationNames) <- dimnames(gams$not_used)[[1]][tmp]
+        gams$not_used <- gams$not_used[-tmp, , drop = FALSE]
+        for (i in seq_along(declarationNames)) {
+          w <- .warning(names(declarationNames)[i],
+                        ": \"",
+                        declarationNames[i],
+                        "\" does not follow the given naming conventions!",
+                        w = w)
+        }
+      }
+    }
+    return(list(gams = gams, w = w))
+  }
+
+  .checkAppearanceUsage <- function(ap, modulesInfo, w) {
+    # are any non-interface core variables used in other places than the core?
+    wrong <- names(ap$type)[ap$type == "" & (rowSums(ap$appearance) > 1 | !ap$appearance[, "core"])]
+    for (wrong_item in wrong) {
+      mod <- unique(sub("\\.[^\\.]*$", "", dimnames(ap$appearance)[[2]][ap$appearance[w, ] > 0]))
+      w <- .warning(wrong_item,
+                    " appears in \"",
+                    paste(mod, collapse = "\", \""),
+                    "\" but its name suggests that it is core only!",
+                    w = w)
+    }
+
+    # are any module variables used somewhere else?
+    for (i in seq_len(dim(modulesInfo)[1])) {
+      mod <- modulesInfo[i, "name"]
+      number <- modulesInfo[i, "number"]
+      var <- names(ap$type)[ap$type == number]
+      for (v in var) {
+        outsideAppearance <- ap$appearance[v, grep(mod, dimnames(ap$appearance)[[2]], invert = TRUE)]
+        if (any(outsideAppearance > 0)) {
+          w <- .warning(v,
+                        " appears outside of module \"",
+                        mod,
+                        "\"! (",
+                        paste(names(outsideAppearance)[outsideAppearance], collapse = ", "),
+                        ")",
+                        w = w)
+        }
+      }
+    }
+
+    # are any module numbers of modules used which do not exist?
+    var <- names(ap$type)[!(sub("o", "", ap$type) %in% c("", "m", modulesInfo[, "number"]))]
+    for (v in var) {
+      w <- .warning(v, " uses the number of a non-existing module!", w = w)
+    }
+
+    return(w)
+  }
+
+  .getInterfaceInfo <- function(ap, gams, w) {
+    # setting up a list of used interfaces for each module
+    interfaceInfo <- list()
+    ifs <- unique(names(ap$type)[ap$type == "m"])
+    for (i in ifs) {
+      mod <- unique(sub("\\.[^\\.]*$", "", dimnames(ap$appearance)[[2]][ap$appearance[i, ] > 0]))
+      if (length(mod) == 1) {
+        w <- .warning(i,
+                      " appears only in \"",
+                      mod,
+                      "\" even though it is supposed to be an interface (perhaps only in not_used.txt?)!",
+                      w = w)
+      } else {
+        whereDeclared <- unique(sub("\\.[^\\.]*$", "", rownames(gams$declarations)[gams$declarations[, 1] == i]))
+        if (length(whereDeclared) > 1) {
+          w <- .warning(i,
+                        " is declared more than once in the following parts of the code: ",
+                        paste(whereDeclared, collapse = ", "),
+                        w = w)
+        }
+        if (length(whereDeclared) == 0) {
+          w <- .warning("Could not find any declaration for ", i, w = w)
+          whereDeclared <- "NOWHEREATALL!"
+        }
+        for (m in mod) {
+          if (m == whereDeclared[1]) {
+            interfaceInfo[[m]] <- c(interfaceInfo[[m]], "out" = i)
+          } else {
+            interfaceInfo[[m]] <- c(interfaceInfo[[m]], "in" = i)
+          }
+        }
+      }
+    }
+    return(list(interfaceInfo = interfaceInfo, w = w))
+  }
+
+  .emitTimingMessage <- function(message, ptm) {
+    # Print a timing message, nicely formatted
+    message(str_pad(message, 40, "right"),
+            "(time elapsed: ",
+            format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2),
+            ")")
   }
 
   message("\n Running codeCheck...")
+
   ptm <- proc.time()["elapsed"]
-  all_files <-list.files(path=path,pattern="\\.gms$",recursive=TRUE)
-  module_files <-  paste0(path,"/",grep(paste("^",modulepath,sep=""),all_files,value=TRUE))
-  core_files <- Sys.glob(paste0(path,"/",core_files))
-  core <- codeExtract(core_files,"core")
-  modulesInfo <- getModules(paste0(path,"/",modulepath))
-  modules <- list()
-  for (i in 1:dim(modulesInfo)[1]) {
-      m <- modulesInfo[i, ]
-      for (j in strsplit(m["realizations"], ",")[[1]]) {
-          tmp <- codeExtract(grep(paste0(m["folder"],"/",j,"/"), module_files,value = TRUE),name=paste(m["name"],j,sep="."))
-          modules$code <- c(modules$code, tmp$code)
-          modules$declarations <- rbind(modules$declarations, tmp$declarations)
-          not_used <- paste0(path,"/",modulepath,"/",m["folder"],"/", j,"/not_used.txt")
-          if (file.exists(not_used)) {
-              tmp <- as.matrix(suppressWarnings(read.csv(not_used, as.is = TRUE, comment.char = "#")))
-              dimnames(tmp)[[1]] <- rep(paste(m["name"], j,sep = "."), dim(tmp)[1])
-              modules$not_used <- rbind(modules$not_used, tmp)
-          }
-      }
+
+
+  modulesInfo <- getModules(paste0(path, "/", modulepath))
+  gams <- .collectData(path = path, modulepath = modulepath, coreFiles = core_files, modulesInfo = modulesInfo)
+
+  if (debug) {
+    gamsBackup <- gams
   }
 
-  gams <- list(code=c(core$code,modules$code),declarations=rbind(core$declarations,modules$declarations),not_used = modules$not_used)
+  .emitTimingMessage(" Finished data collection...", ptm)
 
-  message(" Finished data collection...            (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
-  if(debug) gams_backup <- gams
-
-  # from here on core contains the core code (without comments) and the corresponding declarations
-  # and modules contains the same information for all realizations of all modules
-  # now the code checking can start
-
+  # warnings
   w <- NULL
 
-  # Do all declarations follow the naming conventions? (see the coding etiquette at
-  # https://github.com/magpiemodel/tutorials/blob/master/4_GAMScodeStructure.md#23-coding-etiquette-variable-and-parameter-naming
-  # for further information)
-  # Remove objects which do not follow the naming conventions from the declarations set as
-  # they would otherwise cause problems in what follows
-  tmp <- grep("^[qvsfipoxcm]{1}[cqv]?(m|[0-9]{2}|)_",gams$declarations[,"names"],invert=TRUE)
-  tmp <- tmp[gams$declarations[tmp,"type"]!="set"] #remove set entries from analysis
-  if(length(tmp)>0) {
-    no_ <- gams$declarations[tmp,"names"]
-    nodesc_ <- gams$declarations[tmp,"description"]
-    gams$declarations <- gams$declarations[-tmp,]
-    for(i in 1:length(no_)) w <- .warning(names(no_)[i],": \"",no_[i],"\" does not follow the given naming conventions (description = \"",nodesc_[i],"\")!",w=w)
-  }
-  if (!is.null(gams$not_used)) {
-    tmp <- grep("_", gams$not_used[, "name"], invert = TRUE)
-    if (length(tmp) > 0) {
-      no_ <- gams$not_used[tmp, "name"]
-      names(no_) <- dimnames(gams$not_used)[[1]][tmp]
-      gams$not_used <- gams$not_used[-tmp, , drop = FALSE]
-      for (i in 1:length(no_)) w <- .warning(names(no_)[i], ": \"",no_[i], "\" does not follow the given naming conventions!",w=w)
-    }
-  }
+  ret <- .checkNamingConventions(gams = gams, w = w)
+  gams <- ret$gams
+  w <- ret$w
 
-  message(" Naming conventions check done...       (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
+  .emitTimingMessage(" Naming conventions check done...", ptm)
 
   # Check appearance of objects
   ap <- checkAppearance(gams)
-  w <- c(w,ap$warnings)
+  w <- c(w, ap$warnings)
 
-  message(" Investigated variable appearances...   (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
+  .emitTimingMessage(" Investigated variable appearances...", ptm)
 
+  w <- .checkAppearanceUsage(ap = ap, modulesInfo = modulesInfo, w = w)
 
-  #are any non-interface core variables used in other places than the core?
-  wrong <- names(ap$type)[ap$type == "" & (rowSums(ap$appearance) > 1 | !ap$appearance[, "core"])]
-  for (wrong_item in wrong) {
-    mod <- unique(sub("\\.[^\\.]*$", "", dimnames(ap$appearance)[[2]][ap$appearance[w,]>0]))
-    w <- .warning(wrong_item, " appears in \"", paste(mod, collapse = "\", \""),"\" but its name suggests that it is core only!",w=w)
-  }
-
-  #are any module variables used somewhere else?
-  for(i in 1:dim(modulesInfo)[1]) {
-    mod <- modulesInfo[i,"name"]
-    number <- modulesInfo[i,"number"]
-    var <- names(ap$type)[ap$type==number]
-    for(v in var) {
-      outside_appearance <- ap$appearance[v,grep(mod,dimnames(ap$appearance)[[2]],invert=TRUE)]
-      if(any(outside_appearance>0)) w <- .warning(v, " appears outside of module \"",mod,"\"! (", paste(names(outside_appearance)[outside_appearance],collapse=", "),")",w=w)
-    }
-  }
-
-  #are any module numbers of modules used which do not exist?
-  var <- names(ap$type)[!(sub("o","",ap$type) %in% c("","m",modulesInfo[,"number"]))]
-  for(v in var) {
-    w <- .warning(v, " uses the number of a non-existing module!",w=w)
-  }
-
-  message(" Appearance check done...               (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
+  .emitTimingMessage(" Appearance and usage check done...", ptm)
 
   sap <- checkSwitchAppearance(gams$code)
 
+  .emitTimingMessage(" Switch Appearance check done...", ptm)
 
-  message(" Switch Appearance check done...        (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
+  ret <- .getInterfaceInfo(ap = ap, gams = gams, w = w)
+  interfaceInfo <- ret$interfaceInfo
+  w <- ret$w
 
-
-  #setting up a list of used interfaces for each module
-  interfaceInfo <- list()
-  ifs <- unique(names(ap$type)[ap$type=="m"])
-  for(i in ifs) {
-    mod <- unique(sub("\\.[^\\.]*$","",dimnames(ap$appearance)[[2]][ap$appearance[i,]>0]))
-    if(length(mod)==1) {
-      w <- .warning(i, " appears only in \"",mod,"\" even though it is supposed to be an interface (perhaps only in not_used.txt?)!",w=w)
-    } else {
-      where_declared <- unique(sub("\\.[^\\.]*$","",rownames(gams$declarations)[gams$declarations[,1]==i]))
-      if(length(where_declared)>1) w <- .warning(i, " is declared more than once in the following parts of the code: ",paste(where_declared,collapse=", "),w=w)
-      if(length(where_declared)==0) {
-        w <- .warning("Could not find any declaration for ",i,w=w)
-        where_declared <- "NOWHEREATALL!"
-      }
-      for(m in mod) {
-        if(m==where_declared[1]) {
-          interfaceInfo[[m]] <- c(interfaceInfo[[m]],"out"=i)
-        } else {
-          interfaceInfo[[m]] <- c(interfaceInfo[[m]],"in"=i)
-        }
+  # does the core contain switches for all modules?
+  if (test_switches) {
+    if (!all(names(interfaceInfo) %in% c("core", sap$switches))) {
+      for (f in names(interfaceInfo)[!(names(interfaceInfo) %in% c("core", sap$switches))]) {
+        w <- .warning("Switch for module \"", f, "\" is missing in the code!", w = w)
       }
     }
   }
 
-  #does the core contain switches for all modules?
-  if(test_switches) {
-    if(!all(names(interfaceInfo) %in% c("core",sap$switches))){
-      for(f in names(interfaceInfo)[!(names(interfaceInfo) %in% c("core",sap$switches))]) {
-        w <- .warning("Switch for module \"",f,"\" is missing in the code!",w=w)
-      }
-    }
-  }
-
-  #create an object containing switches not related to modules
-  modules <- c("core",getModules(paste0(path,"/",modulepath))[,"name"])
+  # create an object containing switches not related to modules
+  modules <- c("core", modulesInfo[, "name"])
   esap <- sap
-  esap$switches <- sap$switches[!(sap$switches%in%modules)]
-  esap$appearance <- sap$appearance[!(rownames(sap$appearance)%in%modules),]
-  esap$type <- sap$type[!(names(sap$type)%in%modules)]
+  esap$switches <- sap$switches[!(sap$switches %in% modules)]
+  esap$appearance <- sap$appearance[!(rownames(sap$appearance) %in% modules), ]
+  esap$type <- sap$type[!(names(sap$type) %in% modules)]
 
-  #check whether switches contain which are not module switches and which do not contain a prefix
-  if(length(esap$type)>0) {
-    for(i in 1:length(esap$type)) {
-      if(esap$type[i]=="") {
-        w <- .warning("\"",names(esap$type)[i],"\" is neither a module switch nor does it start with prefix \"c\"!",w=w)
-      } else if(esap$type[i]=="c") {
-        if(any(esap$appearance[names(esap$type)[i],colnames(esap$appearance)!="core"])) {
-          w <- .warning("\"",names(esap$type)[i],"\" should be core only!",w=w)
+  # check whether switches contain which are not module switches and which do not contain a prefix
+  if (length(esap$type) > 0) {
+    for (i in seq_along(esap$type)) {
+      if (esap$type[i] == "") {
+        w <- .warning("\"",
+                      names(esap$type)[i],
+                      "\" is neither a module switch nor does it start with prefix \"c\"!",
+                      w = w)
+      } else if (esap$type[i] == "c") {
+        if (any(esap$appearance[names(esap$type)[i], colnames(esap$appearance) != "core"])) {
+          w <- .warning("\"", names(esap$type)[i], "\" should be core only!", w = w)
         }
-      } else if(esap$type[i]=="cm") {
-        #you can add here tests for interface switches!
-      } else if(!suppressWarnings(is.na(as.integer(substring(esap$type[i],2))))) {
-        #check whether switch is only used inside the given module
-        tmp <- modulesInfo[modulesInfo[,"number"]==substring(esap$type[i],2),"name"]
-        tmp2 <- esap$appearance[names(esap$type)[i],grep(paste("^",tmp,"\\.",sep=""),colnames(esap$appearance),invert=TRUE)]
-        if(any(tmp2)) w <- .warning("\"",names(esap$type)[i],"\" does appear in modules ",paste(names(tmp2)[tmp2],collapse=", ")," but should only appear in module ",tmp,"!",w=w)
+      } else if (esap$type[i] == "cm") {
+        # you can add here tests for interface switches!
+      } else if (!suppressWarnings(is.na(as.integer(substring(esap$type[i], 2))))) {
+        # check whether switch is only used inside the given module
+        tmp <- modulesInfo[modulesInfo[, "number"] == substring(esap$type[i], 2), "name"]
+        tmp2 <- esap$appearance[names(esap$type)[i],
+                                grep(paste("^", tmp, "\\.", sep = ""), colnames(esap$appearance), invert = TRUE)]
+        if (any(tmp2)) {
+          w <- .warning("\"",
+                        names(esap$type)[i],
+                        "\" does appear in modules ",
+                        paste(names(tmp2)[tmp2], collapse = ", "),
+                        " but should only appear in module ",
+                        tmp,
+                        "!",
+                        w = w)
+        }
       } else {
-        w <- .warning("\"",names(esap$type)[i],"\" does not follow any of the given name conventions!",w=w)
+        w <- .warning("\"", names(esap$type)[i], "\" does not follow any of the given name conventions!", w = w)
       }
     }
   }
 
-  #do interfaces appear only in not_used.txt files of a module?
-  for(m in names(interfaceInfo)) {
-    r <- grep(paste("^",m,"(\\.|$)",sep=""),dimnames(ap$appearance)[[2]])
-    for(v in interfaceInfo[[m]]) {
-      if(all(ap$appearance[v,r]!=1)) {
-        if(interactive) {
-          tmp <- .choose_option(options=c("yes","no"),"\"",v,"\" appears in some not_used.txt files of module \"",m,"\" but is not used in the code! Should it be removed?")
-          if(tmp=="yes") {
-            tmp_path <- paste(path, modulepath, paste0("[0-9]*_",m), "*/not_used.txt", sep="/")
-            not_used <- Sys.glob(tmp_path)
-            for(n in not_used) {
-              tmp <- read.csv(n,stringsAsFactors = FALSE, comment.char = "#")
-              tmp <- tmp[tmp$name != v,]
-              write.table(tmp,n,sep=",",quote = FALSE,row.names = FALSE)
+  # do interfaces appear only in not_used.txt files of a module?
+  for (m in names(interfaceInfo)) {
+    r <- grep(paste("^", m, "(\\.|$)", sep = ""), dimnames(ap$appearance)[[2]])
+    for (v in interfaceInfo[[m]]) {
+      if (all(ap$appearance[v, r] != 1)) {
+        if (interactive) {
+          answer <- chooseFromList(c("yes", "no"),
+                                   "choices",
+                                   multiple = FALSE,
+                                   userinfo = paste0("\"",
+                                                     v,
+                                                     "\" appears in some not_used.txt files of module \"",
+                                                     m,
+                                                     "\" but is not used in the code! Should it be removed?")
+          )
+          if (answer == "yes") {
+            notUsedGlob <- paste(path, modulepath, paste0("[0-9]*_", m), "*/not_used.txt", sep = "/")
+            notUsedPath <- Sys.glob(notUsedGlob)
+            for (n in notUsedPath) {
+              tmp <- read.csv(n, stringsAsFactors = FALSE, comment.char = "#")
+              tmp <- tmp[tmp$name != v, ]
+              write.table(tmp, n, sep = ",", quote = FALSE, row.names = FALSE)
             }
-            message('"',v,'" has been removed from not_used.txt files!\n')
+            message('"', v, '" has been removed from not_used.txt files!\n')
           }
         } else {
-          w <- .warning("\"",v,"\" appears in some not_used.txt files of module \"",m,"\" but is not used in the code!",w=w)
+          w <- .warning("\"",
+                        v,
+                        "\" appears in some not_used.txt files of module \"",
+                        m,
+                        "\" but is not used in the code!",
+                        w = w)
         }
       }
     }
   }
 
-  #are all interfaces of a module addressed in all of its realizations?
-  for(m in names(interfaceInfo)) {
-    r <- grep(paste("^",m,"(\\.|$)",sep=""),dimnames(ap$appearance)[[2]])
-    for(v in interfaceInfo[[m]]) {
-      if(!all(ap$appearance[v,r]>0)) {
-        realization <- sub("^[^\\.]*\\.","",dimnames(ap$appearance)[[2]][r])
-        availability <- ap$appearance[v,r]
-        if(interactive) {
-          for(i in 1:length(availability)) {
-            if(availability[i]==0) {
-              tmp <- .choose_option(options=c("yes","no"),'"',v,'" is not addressed in realization "',realization[i],'" of module "',m,'"! Does that make sense?')
-              if(tmp=="no") stop("You need to fix the model code before we can proceed!")
-              if(grepl("^v",v)) {
-                  tmp <- .choose_option(options=c("no","yes"),'"',v,'" is a variable. Are you sure that it does not need to be treated in realization "',realization[i],'" (e.g. fixed to a value)?')
-                  if(tmp=="no") stop("You need to fix the model code before we can proceed!")
+  # are all interfaces of a module addressed in all of its realizations?
+  for (m in names(interfaceInfo)) {
+    r <- grep(paste("^", m, "(\\.|$)", sep = ""), dimnames(ap$appearance)[[2]])
+    for (v in interfaceInfo[[m]]) {
+      if (!all(ap$appearance[v, r] > 0)) {
+        realization <- sub("^[^\\.]*\\.", "", dimnames(ap$appearance)[[2]][r])
+        availability <- ap$appearance[v, r]
+        if (interactive) {
+          for (i in seq_along(availability)) {
+            if (availability[i] == 0) {
+              answer <- chooseFromList(c("yes", "no"),
+                                       "choices",
+                                        multiple = FALSE,
+                                        userinput = paste0('"',
+                                                           v,
+                                                           '" is not addressed in realization "',
+                                                           realization[i],
+                                                           '" of module "',
+                                                           m,
+                                                           '"! Does that make sense?'))
+              if (answer == "no") {
+                stop("You need to fix the model code before we can proceed!")
               }
-              tmp <- .choose_option(options=c("yes","no"),'Should "',v,'" be written to not_used.txt in realization "',realization[i],'" of module "',m,'"?')
-              if(tmp=="yes") {
-                tmp_path <- paste(path, modulepath, paste0("[0-9]*_",m), realization[i], sep="/")
-                not_used <- paste(Sys.glob(tmp_path),"not_used.txt",sep="/")
-                if(!file.exists(not_used)) w <- .warning('Do not forget to add the not_used.txt file in realization "',realization[i],'" of module "',m,'" to the repository!',w=w)
-                tmp <- data.frame(name=v,type="input",reason="questionnaire")
-                write.table(tmp,not_used,sep=",",quote = FALSE,row.names = FALSE, append=file.exists(not_used), col.names = !file.exists(not_used))
-                message('"',v,'" has been written to not_used.txt!')
+              if (grepl("^v", v)) {
+                answer <- chooseFromList(c("yes", "no"),
+                                         "choices",
+                                          multiple = FALSE,
+                                          userinput = paste0(
+                                            '"',
+                                            v,
+                                            '" is a variable.",
+                                            " Are you sure that it does not need to be treated in realization "',
+                                            realization[i],
+                                            '" (e.g. fixed to a value)?')
+                )
+                if (answer == "no") {
+                  stop("You need to fix the model code before we can proceed!")
+                }
+              }
+              answer <- chooseFromList(c("yes", "no"),
+                                         "choices",
+                                          multiple = FALSE,
+                                          userinput = paste0(
+                                            'Should "',
+                                            v,
+                                            '" be written to not_used.txt in realization "',
+                                            realization[i],
+                                            '" of module "',
+                                            m,
+                                            '"?')
+              )
+              if (answer == "yes") {
+                notUsedGlob <- paste(path, modulepath, paste0("[0-9]*_", m), realization[i], sep = "/")
+                notUsedPath <- paste(Sys.glob(notUsedGlob), "not_used.txt", sep = "/")
+                if (!file.exists(notUsedPath)) {
+                  w <- .warning('Do not forget to add the not_used.txt file in realization "',
+                                realization[i],
+                                '" of module "',
+                                m,
+                                '" to the repository!',
+                                w = w)
+                }
+                tmp <- data.frame(name = v, type = "input", reason = "questionnaire")
+                write.table(tmp,
+                            notUsedPath,
+                            sep = ",",
+                            quote = FALSE,
+                            row.names = FALSE,
+                            append = file.exists(notUsedPath),
+                            col.names = !file.exists(notUsedPath))
+                message('"', v, '" has been written to not_used.txt!')
               }
             }
           }
         } else {
-          w <- .warning("\"",v,"\" is not addressed in all realizations of module \"",m,"\"! (",paste(realization,availability,collapse=", ",sep="="),") (0 = missing, 1 = in code, 2 = in not_used.txt)",w=w)
+          w <- .warning("\"",
+                        v,
+                        "\" is not addressed in all realizations of module \"",
+                        m,
+                        "\"! (",
+                        paste(realization, availability, collapse = ", ", sep = "="),
+                        ") (0 = missing, 1 = in code, 2 = in not_used.txt)",
+                        w = w)
         }
       }
     }
   }
 
-  message(" Interface collection and check done... (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
+  .emitTimingMessage(" Interface collection and check done...", ptm)
 
+  w <- .checkInputFiles(w = w, path = path, modulepath = modulepath)
 
-  w <- .check_input_files(w=w,path=path,modulepath=modulepath)
-  message(" Input folder check done...             (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
-
+  .emitTimingMessage(" Input folder check done...", ptm)
 
   # Do all declarations come with a description?
-  w <- checkDescription(gams,w)
+  w <- checkDescription(gams, w)
 
-  message(" Description check done...              (time elapsed: ",format(proc.time()["elapsed"]-ptm,width=6,nsmall=2,digits=2),")")
+  .emitTimingMessage(" Description check done...", ptm)
 
-  if(debug) {
-    out <- list(interfaceInfo=interfaceInfo,ap=ap,gams=gams,gams_backup=gams_backup,sap=sap,esap=esap,modulesInfo=modulesInfo)
-  } else if(details) {
+  if (debug) {
+    out <- list(interfaceInfo = interfaceInfo,
+                ap = ap,
+                gams = gams,
+                gams_backup = gamsBackup,
+                sap = sap,
+                esap = esap,
+                modulesInfo = modulesInfo)
+  } else if (details) {
     d <- gams$declarations
-    d <- cbind(d,origin=rownames(d))
+    d <- cbind(d, origin = rownames(d))
     rownames(d) <- NULL
     d <- as.data.frame(d, stringsAsFactors = FALSE)
-    mi <- as.data.frame(modulesInfo,stringsAsFactors = FALSE)
-    out <- list(interfaceInfo=interfaceInfo,declarations=d,appearance=ap$appearance,setappearance=ap$setappearance,modulesInfo=mi)
+    mi <- as.data.frame(modulesInfo, stringsAsFactors = FALSE)
+    out <- list(interfaceInfo = interfaceInfo,
+                declarations = d,
+                appearance = ap$appearance,
+                setappearance = ap$setappearance,
+                modulesInfo = mi)
   } else {
     out <- interfaceInfo
   }
 
-  if(is.null(w)) {
+  if (is.null(w)) {
     message(" All codeCheck tests passed!")
   } else {
-    if(strict) stop("codeCheck returned warnings. Fix warnings to proceed!")
+    if (strict) stop("codeCheck returned warnings. Fix warnings to proceed!")
     message(" codeCheck reported code inconsistencies. Please fix the given warnings!")
   }
-  attr(out,"last.warning") <- w
+  attr(out, "last.warning") <- w
   return(out)
 }

--- a/R/selectScript.R
+++ b/R/selectScript.R
@@ -35,19 +35,6 @@ selectScript <- function(folder = ".", ending = "R") { # nolint
     return(out)
   }
 
-  getLine <- function() {
-    # gets characters (line) from the terminal or from a connection
-    # and returns it
-    if (interactive()) {
-      s <- readline()
-    } else {
-      con <- file("stdin")
-      s <- readLines(con, 1, warn = FALSE)
-      on.exit(close(con)) # nolint
-    }
-    return(s)
-  }
-
   maxNchar <- function(x, width, prefix = "-> ", suffix = " <-", sep = "-") {
     width <- width - 7
     x <- capture.output(cat(strsplit(x, " ")[[1]], fill = width))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.18.0**
+R package **gms**, version **0.18.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.18.0, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.18.1, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark},
   year = {2022},
-  note = {R package version 0.18.0},
+  note = {R package version 0.18.1},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/man/codeCheck.Rd
+++ b/man/codeCheck.Rd
@@ -52,7 +52,7 @@ the code.
 }
 \examples{
 # check code consistency of dummy model
-codeCheck(system.file("dummymodel",package="gms"))
+codeCheck(system.file("dummymodel", package = "gms"))
 
 }
 \seealso{


### PR DESCRIPTION
Hi,

There was a name clash in `codeCheck` between the index variable in a for loop and the more or less global warnings vector, both named `w`. Maybe a cautionary tale about one-character variable names?

Anyway, lucode2 decided that because I fixed this name clash, I should also completely refactor `codeCheck` to make the linter happy. And who am I to disagree? The linter is not yet fully happy now, but at least it is a lot happier. There are still a couple functions to be extracted out of the big block of code, and some other weird things to fix, but I think it is less intimidating now. And a lot is simply not fixable without changing the API, like the shadowing of the global name `debug`.

Additionally, I found one more `getLine` that can go away.

I tested this by throwing it at a REMIND with a small error, which was detected. So it seems at least the happy path is not horribly broken?

Cheers,

Mika