### PR TITLE
add option to stop download_distribute() if files are missing

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3876084'
+ValidationKey: '4049640'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3855200'
+ValidationKey: '3876084'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.20.1
+Version: 0.21.0
 Date: 2022-10-19
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.20.0
-Date: 2022-10-11
+Version: 0.20.1
+Date: 2022-10-19
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/download_distribute.R
+++ b/R/download_distribute.R
@@ -1,17 +1,21 @@
 #' Download and unpack compressed data from repositories
-#' 
+#'
 #' Downloads a list of tgz files from a list of repos and unpacks them
-#' 
+#'
+#' @md
 #' @param files a vector of files containing input data, if a file is no .tgz it will be downloaded and not unpacked
-#' @param repositories a list of repositories (please pay attention to the list format!) in which the files 
-#' should be searched for. Files will be searched in all repositories until found, always starting with the 
+#' @param repositories a list of repositories (please pay attention to the list format!) in which the files
+#' should be searched for. Files will be searched in all repositories until found, always starting with the
 #' first repository in the list. The argument must have the format of a named list with the url of the repository
 #' as name and a corresponding list of options such as username or password to access the repository as value. If
-#' no options are required the value has to be NULL. (e.g. 
+#' no options are required the value has to be NULL. (e.g.
 #' list("ftp://my_pw_protected_server.de/data"=list(user="me",password=12345), "http://free_server.de/dat"=NULL))
 #' @param modelfolder main model folder
 #' @param additionalDelete information which additonal data should be deleted before new data are downloaded and distributed
 #' @param debug switch for debug mode with additional diagnostic information
+#' @param stopOnMissing Boolean passed along to [download_unpack()] to stop if
+#'   any file in `files` could not be downloaded.  Off (`FALSE`) by default.
+#'
 #' @return Information about the download process in form of a data.frame with data sets as row names and repositories
 #' (where it was downloaded from) and corresponding md5sum as columns
 #' @author Jan Philipp Dietrich, Lavinia Baumstark
@@ -21,15 +25,16 @@ download_distribute <- function(files,
                                 repositories=list("/p/projects/rd3mod/inputdata/output"=NULL),
                                 modelfolder=".",
                                 additionalDelete=NULL,
-                                debug=FALSE) {
-  
+                                debug=FALSE,
+                                stopOnMissing = FALSE) {
+
   cdir <- getwd()
   setwd(modelfolder)
   on.exit(setwd(cdir))
-  
+
   ########## GENERATE INFORMATION FOR DESTINATION ############################
   file2destination <- getfiledestinations()
-  
+
   ########## GENERAL CLEAN UP ################################################
   # delete old input files to avoid mixed inputs in the case that data
   # download fails at some point
@@ -39,18 +44,20 @@ download_distribute <- function(files,
   # delete additional files not treated by copy_input
   if(!is.null(additionalDelete)) delete_olddata(additionalDelete)
   message("done!\n")
-  
+
   ########## DATA DOWNLOAD ###################################################
   # load data from source and unpack it
-  filemap <- download_unpack(input=files, targetdir="input", repositories=repositories, debug=debug)
-  
+  filemap <- download_unpack(input = files, targetdir = "input",
+                             repositories = repositories, debug = debug,
+                             stopOnMissing = stopOnMissing)
+
   ########## COPY MAGPIE INPUT FILES #########################################
   # In the following input files in MAgPIE format are converted (if required) to
   # csX files and copied into the corresponding input folders. In this step also
   # the resolution information in the file name (if existing) is removed to
   # allow a resolution-indepedent gams-sourcecode.
   low_res  <- get_info("input/info.txt","^\\* Output ?resolution:",": ")
-  
+
   # make an educated guess about what the current low res is
   if(is.null(low_res)) {
     guessLowRes <- function(folder) {

--- a/R/download_unpack.R
+++ b/R/download_unpack.R
@@ -3,6 +3,7 @@
 #' Downloads a list of tgz files from a list of repos and unpacks them. If a file is no .tgz-file it will
 #' be only downloaded.
 #'
+#' @md
 #' @param input a vector of files to be downloaded or a cfg list with settings to be used (e.g. containing
 #' cfg$input, cfg$repositories). Settings in the config list will be overwritten by other arguments of
 #' this function if they are not set to NULL
@@ -15,13 +16,18 @@
 #' list("ftp://my_pw_protected_server.de/data"=list(user="me",password=12345), "http://free_server.de/dat"=NULL))
 #' @param debug switch for debug mode with additional diagnostic information
 #' @param unpack if switched off the source files are purley downloaded
+#' @param stopOnMissing Boolean indicating whether to stop if any file in
+#'   `files` could not be downloaded.  Off (`FALSE`) by default.
+
 #' @return Information about the download process in form of a data.frame with data sets as row names and repositories
 #' (where it was downloaded from) and corresponding md5sum as columns
 #' @author Jan Philipp Dietrich
 #' @importFrom utils untar
 #' @export
 
-download_unpack <- function(input, targetdir = "input", repositories = NULL, debug = FALSE, unpack = TRUE) { # nolint
+download_unpack <- function(input, targetdir = "input", repositories = NULL,
+                            debug = FALSE, unpack = TRUE,
+                            stopOnMissing = FALSE) { # nolint
 
   if (is.list(input)) {
     files <- input$input
@@ -90,8 +96,12 @@ download_unpack <- function(input, targetdir = "input", repositories = NULL, deb
 
   if (length(files) > 0) {
     tmp <- paste0("Following files not found:\n  ", paste(files, collapse = "\n  "))
-    warning(tmp)
-    message(tmp)
+    if (stopOnMissing) {
+      stop(tmp)
+    } else {
+      warning(tmp)
+      message(tmp)
+    }
   }
   if (is.null(found)) {
     message()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.20.0**
+R package **gms**, version **0.20.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.20.0, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.20.1, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger},
   year = {2022},
-  note = {R package version 0.20.0},
+  note = {R package version 0.20.1},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.20.1**
+R package **gms**, version **0.21.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.20.1, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.21.0, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger},
   year = {2022},
-  note = {R package version 0.20.1},
+  note = {R package version 0.21.0},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
Currently, if any of the files that `download_distribute()` is to process are missing, it will tell the user so, e.g.
```
Following files not found:
  rev6.316_62eff8f7_remind.tgz
  rev6.316_62eff8f7_validationremind.tgz
```
just to continue with lots of
```
   f_maxProdGradeRegiWindOff.cs3r                                                                                            ->  FAILED!
   pm_histCap_windoff.cs3r                                                                                                   ->  FAILED!
   p_histCapFac_windoff.cs4r                                                                                                 ->  FAILED!
```
flushing the interesting information way past what the user can see.

With this patch, the argument `stopOnMissing` is passed from `download_distribute()` (which seems to be the user-facing function) to `download_unpack()`, which stops processing if any of the files in `input` cannot be downloaded, looking like
```
Load data..
  try ~/PIK/Remind_input
    -> CESparametersAndGDX_346023c22fb098052539fbbfdda2041b5114d82c.tgz
 Error in download_unpack(input = files, targetdir = "input", repositories = repositories, : 
Following files not found:
rev6.316_62eff8f7_remind.tgz
rev6.316_62eff8f7_validationremind.tgz
```
`stopOnMissing` defaults to `FALSE` in both functions, preserving the existing behaviour.  This could be changed if there is no behaviour dependent on unpacking of partial input data to any model.