### PR TITLE
Use a self-explanatory reason when adding to not_used.txt

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4282158'
+ValidationKey: '4439000'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.22.2",
+  "version": "0.23.0",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.22.2
-Date: 2022-10-24
+Version: 0.23.0
+Date: 2022-11-04
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -368,7 +368,7 @@ codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*
                                 '" to the repository!',
                                 w = w)
                 }
-                tmp <- data.frame(name = v, type = "input", reason = "questionnaire")
+                tmp <- data.frame(name = v, type = "input", reason = "added by codeCheck")
                 write.table(tmp,
                             notUsedPath,
                             sep = ",",

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -8,7 +8,7 @@
 #' @param path path of the main folder of the model
 #' @param modulepath path to the module folder relative to "path"
 #' @param core_files list of files that belong to the core (wildcard expansion is supported)
-#' @param debug If TRUE additional information will be returned usefule for
+#' @param returnDebug If TRUE additional information will be returned useful for
 #' debugging the codeCheck function
 #' @param interactive activates an interactive developer mode in which some of
 #' the warnings can be fixed interactively.
@@ -21,9 +21,9 @@
 #' it will provide a table containing all declarations in the code, an appearance table listing the appearance of all
 #' objects in the code and information about the existing modules. The format is
 #' list(interfaceInfo,declarations,appearance,modulesInfo). This setting will be ignored
-#' when debug is set to TRUE.
+#' when returnDebug is set to TRUE.
 #' @return A list of all modules containing the interfaces for each module. Or more detailed output if either
-#' \code{details} or \code{debug} is set to TRUE.
+#' \code{details} or \code{returnDebug} is set to TRUE.
 #' @author Jan Philipp Dietrich
 #' @export
 #' @seealso \code{\link{codeExtract}},\code{\link{readDeclarations}}
@@ -33,8 +33,14 @@
 #' # check code consistency of dummy model
 #' codeCheck(system.file("dummymodel", package = "gms"))
 #'
-codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*.gms", "main.gms"),
-                      debug = FALSE, interactive = FALSE, test_switches = TRUE, strict = FALSE, details = FALSE) {
+codeCheck <- function(path = ".",
+                      modulepath = "modules",
+                      core_files = c("core/*.gms", "main.gms"),  # nolint: object_name_linter
+                      returnDebug = FALSE,
+                      interactive = FALSE,
+                      test_switches = TRUE,  # nolint: object_name_linter
+                      strict = FALSE,
+                      details = FALSE) {
 
   .checkInputFiles <- function(w, path = ".", modulepath = "modules") {
     inputgms <- Sys.glob(paste0(path, "/", modulepath, "/*/*/input.gms"))
@@ -93,7 +99,7 @@ codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*
 
   .checkNamingConventions <- function(gams, w) {
     # Do all declarations follow the naming conventions? (see the coding etiquette at
-    # https://github.com/magpiemodel/tutorials/blob/master/4_GAMScodeStructure.md#23-coding-etiquette-variable-and-parameter-naming
+    # https://github.com/magpiemodel/tutorials/blob/master/4_GAMScodeStructure.md#23-coding-etiquette-variable-and-parameter-naming # nolint
     # for further information)
     # Remove objects which do not follow the naming conventions from the declarations set as
     # they would otherwise cause problems in what follows
@@ -184,7 +190,7 @@ codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*
   modulesInfo <- getModules(paste0(path, "/", modulepath))
   gams <- .collectData(path = path, modulepath = modulepath, coreFiles = core_files, modulesInfo = modulesInfo)
 
-  if (debug) {
+  if (returnDebug) {
     gamsBackup <- gams
   }
 
@@ -405,7 +411,7 @@ codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*
 
   .emitTimingMessage(" Description check done...", ptm)
 
-  if (debug) {
+  if (returnDebug) {
     out <- list(interfaceInfo = interfaceInfo,
                 ap = ap,
                 gams = gams,
@@ -434,7 +440,7 @@ codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*
     if (strict) stop("codeCheck returned warnings. Fix warnings to proceed!")
     message(" codeCheck reported code inconsistencies. Please fix the given warnings!")
   }
-  attr(out, "last.warning") <- w
+  attr(out, "last.warning") <- w  # nolint: object_name_linter
   return(out)
 }
 
@@ -478,4 +484,3 @@ codeCheck <- function(path = ".", modulepath = "modules", core_files = c("core/*
 
   return(w)
 }
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.22.2**
+R package **gms**, version **0.23.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.22.2, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2022). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.23.0, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2022},
-  note = {R package version 0.22.2},
+  note = {R package version 0.23.0},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/man/codeCheck.Rd
+++ b/man/codeCheck.Rd
@@ -8,7 +8,7 @@ codeCheck(
   path = ".",
   modulepath = "modules",
   core_files = c("core/*.gms", "main.gms"),
-  debug = FALSE,
+  returnDebug = FALSE,
   interactive = FALSE,
   test_switches = TRUE,
   strict = FALSE,
@@ -22,7 +22,7 @@ codeCheck(
 
 \item{core_files}{list of files that belong to the core (wildcard expansion is supported)}
 
-\item{debug}{If TRUE additional information will be returned usefule for
+\item{returnDebug}{If TRUE additional information will be returned useful for
 debugging the codeCheck function}
 
 \item{interactive}{activates an interactive developer mode in which some of
@@ -39,11 +39,11 @@ at the end of the analysis. Useful to enforce clean code.}
 it will provide a table containing all declarations in the code, an appearance table listing the appearance of all
 objects in the code and information about the existing modules. The format is
 list(interfaceInfo,declarations,appearance,modulesInfo). This setting will be ignored
-when debug is set to TRUE.}
+when returnDebug is set to TRUE.}
 }
 \value{
 A list of all modules containing the interfaces for each module. Or more detailed output if either
-\code{details} or \code{debug} is set to TRUE.
+\code{details} or \code{returnDebug} is set to TRUE.
 }
 \description{
 Checks GAMS code for consistency. Throws out warnings if something is wrong

--- a/tests/testthat/test-codeCheck.R
+++ b/tests/testthat/test-codeCheck.R
@@ -12,7 +12,7 @@ test_that("interfaces properly detected and plotted", {
 test_that("return value of codeCheck in debug mode is correct", {
   expectedResult <- c("interfaceInfo", "ap", "gams", "gams_backup", "sap", "esap", "modulesInfo")
 
-  cc <- codeCheck(system.file("dummymodel", package = "gms"), debug = TRUE)
+  cc <- codeCheck(system.file("dummymodel", package = "gms"), returnDebug = TRUE)
   expect_identical(names(cc), expectedResult)
 })
 


### PR DESCRIPTION
Hi,

The given `reason` used to be `questionnaire`, now it is `added by codeCheck`, which is more self-explanatory, I hope.

Also, I added more `nolints` to things that the linter doesn't like which we won't fix. Also, I renamed the parameter `debug` to `returnDebug`, which is an API change, but:
* the parameter is not used throughout the pik-piam universe (searched via `reposearch`)
* it is only meant to be used interactively and seldom, so hopefully nobodies workflows will be broken.
* keeping the parameter name not only scares the linter, but also breaks actual debugging via `debug()`, so I think renaming makes proper debugging *easier*.

Cheers

Mika