### PR TITLE
improve performance of checkNoTabs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4653600'
+ValidationKey: '4676605'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.24.0
-Date: 2023-02-02
+Version: 0.24.1
+Date: 2023-02-17
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -11,33 +11,35 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary()
+build:          ## Build the package using lucode2::buildLibrary().
 	Rscript -e 'lucode2::buildLibrary()'
 
 check:          ## Build documentation and vignettes, run testthat tests,
-                ## and check if code etiquette is followed using lucode2::check()
+                ## and check if code etiquette is followed using lucode2::check().
 	Rscript -e 'lucode2::check()'
 
 test:           ## Run testthat tests
 	Rscript -e 'devtools::test(show_report = TRUE)'
 
-lint:           ## Check if code etiquette is followed using lucode2::lint()
+lint:           ## Check if code etiquette is followed using lucode2::lint().
                 ## Only checks files you changed.
 	Rscript -e 'lucode2::lint()'
 
-lint-all:       ## Check if code etiquette is followed using lucode2::lint()
+lint-all:       ## Check if code etiquette is followed using lucode2::lint().
                 ## Checks all files.
 	Rscript -e 'lucode2::lint(".")'
 
-format:         ## Apply auto-formatting to changed files and lint afterwards
+format:         ## Apply auto-formatting to changed files and lint afterwards.
 	Rscript -e 'lucode2::autoFormat()'
 
-format-all:     ## Apply auto-formatting to all files and lint afterwards
+format-all:     ## Apply auto-formatting to all files and lint afterwards.
 	Rscript -e 'lucode2::autoFormat(files=list.files("./R", full.names = TRUE, pattern = "\\.R"))'
 
-install:        ## Install the package locally via devtools::install()
-	Rscript -e 'devtools::install(upgrade = "never")'
+install:        ## Install the package locally via devtools::install() after
+                ## generating NAMESPACE and docs (see docs target).
+	Rscript -e 'roxygen2::roxygenize(); devtools::install(upgrade = "never")'
 
-docs:           ## Generate the package documentation (man/*.Rd files) via roxygen2::roxygenize(),
-                ## view the generated documentation with `?package::function`
+docs:           ## Generate the package documentation (man/*.Rd files) and
+                ## NAMESPACE via roxygen2::roxygenize(), view the generated
+                ## documentation with `?package::function`.
 	Rscript -e 'roxygen2::roxygenize()'

--- a/R/checkNoTabs.R
+++ b/R/checkNoTabs.R
@@ -5,6 +5,7 @@
 #'
 #' @param pattern A regular expression. Only files matching this pattern will be checked for tabs.
 #' @param exclude A regular expression. Files matching this pattern will never be checked.
+#' @param excludeFolders Paths to folders that should not be checked.
 #' @return Invisibly, the list of files that were checked.
 #'
 #' @author Pascal Führlich
@@ -14,10 +15,16 @@
 #' gms::checkNoTabs(utils::glob2rx("*.R"))
 #' }
 #' @export
-checkNoTabs <- function(pattern, exclude = NULL) {
-  filesToCheck <- list.files(".", pattern = pattern,
-                             all.files = TRUE, full.names = TRUE, recursive = TRUE)
-  if (!is.null(exclude)){
+checkNoTabs <- function(pattern, exclude = NULL, excludeFolders = NULL) {
+  folders <- normalizePath(list.dirs(".", recursive = FALSE))
+  if (!is.null(excludeFolders)) {
+    folders <- setdiff(folders, normalizePath(excludeFolders))
+  }
+  filesToCheck <- c(list.files(folders, pattern = pattern,
+                               all.files = TRUE, full.names = TRUE, recursive = TRUE),
+                    list.files(".", pattern = pattern,
+                               all.files = TRUE, full.names = TRUE, recursive = FALSE))
+  if (!is.null(exclude)) {
     filesToCheck <- grep(exclude, filesToCheck, invert = TRUE, value = TRUE)
   }
 

--- a/R/checkNoTabs.R
+++ b/R/checkNoTabs.R
@@ -11,7 +11,8 @@
 #' @author Pascal Führlich
 #' @examples
 #' \dontrun{
-#' gms::checkNoTabs(pattern = "\\.(R|gms|cfg|bib)$", exclude = "output/|renv/")
+#' gms::checkNoTabs(pattern = "\\.(R|Rprofile|gms|cfg|bib)$",
+#'                  excludeFolders = c("output", "renv", ".git"))
 #' gms::checkNoTabs(utils::glob2rx("*.R"))
 #' }
 #' @export

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.24.0**
+R package **gms**, version **0.24.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.24.0, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.24.1, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.24.0},
+  note = {R package version 0.24.1},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/man/checkAppearance.Rd
+++ b/man/checkAppearance.Rd
@@ -11,8 +11,8 @@ checkAppearance(x)
 }
 \value{
 A list with four elements: appearance, setappearance, type and
-warnings. Appearance is a matrix containing values which indicate whether an
-object appears in a part of the code or not (e.g. indicates whether "vm_example"
+warnings. Appearance is a matrix containing values which indicate whether an 
+object appears in a part of the code or not (e.g. indicates whether "vm_example" 
 appears in realization "on" of module "test" or not.). 0 means that it does not appear,
 1 means that it appears in the code and 2 means that it appears in the
 not_used.txt. setappearance contains the same information but for sets instead of other

--- a/man/checkNoTabs.Rd
+++ b/man/checkNoTabs.Rd
@@ -4,12 +4,14 @@
 \alias{checkNoTabs}
 \title{checkNoTabs}
 \usage{
-checkNoTabs(pattern, exclude = NULL)
+checkNoTabs(pattern, exclude = NULL, excludeFolders = NULL)
 }
 \arguments{
 \item{pattern}{A regular expression. Only files matching this pattern will be checked for tabs.}
 
 \item{exclude}{A regular expression. Files matching this pattern will never be checked.}
+
+\item{excludeFolders}{Paths to folders that should not be checked.}
 }
 \value{
 Invisibly, the list of files that were checked.
@@ -20,7 +22,8 @@ Will throw an error with a list of files where tabs were found if any.
 }
 \examples{
 \dontrun{
-gms::checkNoTabs(pattern = "\\\\.(R|gms|cfg|bib)$", exclude = "output/|renv/")
+gms::checkNoTabs(pattern = "\\\\.(R|Rprofile|gms|cfg|bib)$",
+                 excludeFolders = c("output", "renv", ".git"))
 gms::checkNoTabs(utils::glob2rx("*.R"))
 }
 }

--- a/man/interfaceplot.Rd
+++ b/man/interfaceplot.Rd
@@ -83,8 +83,8 @@ that do not arrive at one of the group's nodes are ignored \item
 "outgoing_to_no_return" edges that departing from nodes outside of the
 group and not ending at nodes within the group are ignored }} An example:
 \code{list(list(name = "highlight", nodes = "welfare", color = "#ff8f00",
-  shape = "ellipse", edges_to_highlight = "outgoing", edges_to_ignore =
-  "outside"))}.}
+shape = "ellipse", edges_to_highlight = "outgoing", edges_to_ignore =
+"outside"))}.}
 
 \item{max_length_node_names}{NULL (default value) or an integer n giving the
 maximum number of characters allowed in the node names. If not NULL, node

--- a/man/is.modularGAMS.Rd
+++ b/man/is.modularGAMS.Rd
@@ -9,7 +9,7 @@ is.modularGAMS(path = ".", version = FALSE, modulepath = "modules/")
 \arguments{
 \item{path}{path to the main folder of the model}
 
-\item{version}{if TRUE returns the version of the modular structure or FALSE,
+\item{version}{if TRUE returns the version of the modular structure or FALSE, 
 otherwise returns a boolean indicating whether it is modular or not.}
 
 \item{modulepath}{Module path within the model (relative to the model main

--- a/man/module.skeleton.Rd
+++ b/man/module.skeleton.Rd
@@ -46,7 +46,7 @@ Module phases are automatically detected checking the main code of the
 model, but not checking code in modules. If you want to use additional
 phases which are only included within a module, you need to specify them
 manually by adding a comment into your gams code indicating that there is an
-additional phase. The syntax is "* !add_phase!: \if{html}{\out{<phase>}}", e.g. "*
+additional phase. The syntax is "* !add_phase!: <phase>", e.g. "*
 !add_phase!: new_phase"
 }
 \examples{

--- a/man/update_modules_embedding.Rd
+++ b/man/update_modules_embedding.Rd
@@ -35,7 +35,7 @@ Module phases are automatically detected checking the main code of the
 model, but not checking code in modules. If you want to use additional
 phases which are only included within a module, you need to specify them
 manually by adding a comment into your gams code indicating that there is an
-additional phase. The syntax is "* !add_phase!: \if{html}{\out{<phase>}}", e.g. "*
+additional phase. The syntax is "* !add_phase!: <phase>", e.g. "*
 !add_phase!: new_phase"
 }
 \examples{

--- a/man/writeSets.Rd
+++ b/man/writeSets.Rd
@@ -7,8 +7,8 @@
 writeSets(sets, file = NULL)
 }
 \arguments{
-\item{sets}{a list of sets where every set is another list consisting of
-three entries: name (set name as character), desc (set description as
+\item{sets}{a list of sets where every set is another list consisting of 
+three entries: name (set name as character), desc (set description as 
 character) and items (set elements, either as character vector or data.frame)}
 
 \item{file}{Name of the file the set declarations should be written to. If

--- a/tests/testthat/test-checkNoTabs.R
+++ b/tests/testthat/test-checkNoTabs.R
@@ -25,6 +25,6 @@ test_that("checkNoTabs works", {
 
   expect_error(checkNoTabs("\\.(R|gms|cfg|bib)$", exclude = "output/|renv/"),
                paste0("Please replace tabs with spaces in the following files:\n",
-                      "- ./foo/bar/zab.R\n",
-                      "- ./foo/oof.bib"), fixed = TRUE)
+                      "- .+/foo/bar/zab.R\n",
+                      "- .+/foo/oof.bib"))
 })


### PR DESCRIPTION
checkNoTabs took 2min on the cluster, mostly because it was unnecessarily going through lots of folders (`list.files`). This PR allows pre filtering folders which leads to ~5sec runtime on the cluster in a magpie folder.