### PR TITLE
fix checkNoTabs test for windows

### DIFF
--- a/tests/testthat/test-checkNoTabs.R
+++ b/tests/testthat/test-checkNoTabs.R
@@ -25,6 +25,6 @@ test_that("checkNoTabs works", {
 
   expect_error(checkNoTabs("\\.(R|gms|cfg|bib)$", exclude = "output/|renv/"),
                paste0("Please replace tabs with spaces in the following files:\n",
-                      "- .+/foo/bar/zab.R\n",
-                      "- .+/foo/oof.bib"))
+                      "- .+foo/bar/zab.R\n",
+                      "- .+foo/oof.bib"))
 })


### PR DESCRIPTION
This should fix the problem [here](https://github.com/r-universe/pik-piam/actions/runs/4204456869/jobs/7370956673), the test was assuming `/` where Windows used `\`.