### PR TITLE
Fix chooseFromList for no groups at all

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4857750'
+ValidationKey: '4877432'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "gms: 'GAMS' Modularization Support Package",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "<p>A collection of tools to create, use and maintain modularized model code written in the modeling \n    language 'GAMS' (<https://www.gams.com/>). Out-of-the-box 'GAMS' does not come with support for modularized\n    model code. This package provides the tools necessary to convert a standard 'GAMS' model to a modularized one\n    by introducing a modularized code structure together with a naming convention which emulates local\n    environments. In addition, this package provides tools to monitor the compliance of the model code with\n    modular coding guidelines.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.25.0
-Date: 2023-03-15
+Version: 0.25.1
+Date: 2023-03-16
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -40,10 +40,13 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
   m <- paste0("\n\nPlease choose ", type, ":\n\n")
   # paste groups after each entry and add them to theList as options
   rawNames <- names(theList)
-  groups <- sort(unique(unlist(strsplit(rawNames[nchar(rawNames) > 0], ',', fixed = TRUE))))
+  rawNames <- rawNames[nchar(rawNames) > 0]
+  if (length(rawNames) > 0) {
+    groups <- sort(unique(unlist(strsplit(rawNames, ',', fixed = TRUE))))
+  }
   if (multiple) {
     groupsids <- NULL
-    if (length(groups) > 0) {
+    if (exists("groups")) {
       groupsids <- seq(length(originalList) + 1 + 1 * addAllPattern,
                        length(originalList) + length(groups) + 1 * addAllPattern)
       theList <- c(paste0(str_pad(theList, max(nchar(originalList), 10), side = "right"), " ", names(theList)),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.25.0**
+R package **gms**, version **0.25.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.25.0, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.25.1, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.25.0},
+  note = {R package version 0.25.1},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -45,3 +45,8 @@ test_that("chooseFromList works with multiple groups", {
   expect_identical(chooseFromList(theList, userinput = toString(length(theList) + 2)),
                    theList[names(theList) %in% c("Letter", "Letter,Number", "Number,Letter")])
 })
+
+test_that("chooseFromList works with no groups", {
+  theList <- c("A1", "B", "C", 1, 2, "3C")
+  expect_identical(unname(chooseFromList(theList, userinput = "3")), "B")
+})


### PR DESCRIPTION
https://github.com/pik-piam/gms/pull/58 broke the case where the input is not grouped at all, and unfortunately, the tests didn't catch it. This breaks e.g. `rs2`.

I added a test for this and fixed it.