### PR TITLE
accept a=all and p=pattern in chooseFromList

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4949444'
+ValidationKey: '4973265'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.25.4
-date-released: '2023-05-09'
+version: 0.25.5
+date-released: '2023-05-26'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.25.4
-Date: 2023-05-09
+Version: 0.25.5
+Date: 2023-05-26
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -57,10 +57,14 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
                        " Group\n"))
     }
     # add all and regex pattern as options
-    if (addAllPattern) theList <- c("all", theList, "Search by pattern...")
+    if (addAllPattern) {
+      theList <- c("all", theList, "Search by pattern...")
+      a <- 1
+      p <- length(theList)
+    }
   }
-  m <- c(m, paste(paste(str_pad(seq_along(theList), nchar(length(theList)), side = "left"),
-                        theList, sep = ": "),
+  m <- c(m, paste(paste0(str_pad(seq_along(theList), nchar(length(theList)), side = "left"),
+                        ifelse(theList == "all", ",a: ", ifelse(theList == "Search by pattern...", ",p: ", ": ")), theList),
                   collapse = "\n"))
   m <- c(m, "\n", errormessage, userinfo,
             paste0("\nNumber", if (multiple) "s entered as 2,4:6,9", " or leave empty:"))
@@ -70,8 +74,8 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
   }
   # interpret userinput and perform basic checks
   identifier <- try(eval(parse(text = paste("c(", userinput, ")"))))
-  if (! all(grepl("^[0-9,: ]*$", userinput)) || inherits(identifier, "try-error")) {
-    err <- "Try again, you have to choose some numbers.\n"
+  if (! all(grepl(if (addAllPattern) "^[ap0-9,: ]*$" else "^[0-9,: ]*$", userinput)) || inherits(identifier, "try-error")) {
+    err <- paste0("Try again, you have to choose some numbers. ", attr(identifier, "condition"), "\n")
     return(chooseFromList(originalList, type, userinfo, addAllPattern, returnBoolean, multiple, errormessage = err))
   }
   # check whether all input is usable

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.25.4**
+R package **gms**, version **0.25.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.4, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.5, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.25.4},
+  note = {R package version 0.25.5},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -15,6 +15,10 @@ test_that("check various chooseFromList settings", {
                    c(FALSE, TRUE, FALSE, TRUE, FALSE, FALSE))
   expect_identical(chooseFromList(theList, userinput = "1"),
                    theList)
+  expect_identical(chooseFromList(theList, userinput = "a"),
+                   theList)
+  expect_identical(chooseFromList(theList, userinput = "a,1"),
+                   theList)
   expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "1"),
                    theList[1])
   expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "  1 :  1  "),
@@ -35,6 +39,14 @@ test_that("check various chooseFromList settings", {
                    c("A", "B"))
   expect_identical(theList[choosePatternFromList(theList, pattern = "^[0-9]+$")],
                    theList[names(theList) == "Number"])
+  # Test pattern search by overriding getLine, only works with 'y' because this validates the "are you sure"-question
+  with_mocked_bindings({
+    expect_equal(chooseFromList(c("a", "b", "y"), userinput = "p"), "y")
+    expect_equal(chooseFromList(c("a", "b", "y", "yb"), userinput = "p"), c("y", "yb"))
+    expect_equal(length(chooseFromList(c("a", "b"), userinput = "p")), 0)
+    },
+    getLine = function() return("y")
+  )
 })
 
 test_that("chooseFromList works with multiple groups", {


### PR DESCRIPTION
- if your list is long and you want to select a pattern, it is sometimes tedious to type the number 483 to select a pattern.
- Now, you can type `a` for `all` and `p` for `pattern`
- Also improve the error message by appending the fail message