### PR TITLE
add fixed=TRUE pattern mode to chooseFromList

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4973265'
+ValidationKey: '4997632'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9007
+    rev: v0.3.2.9013
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.25.5
-date-released: '2023-05-26'
+version: 0.25.6
+date-released: '2023-06-14'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.25.5
-Date: 2023-05-26
+Version: 0.25.6
+Date: 2023-06-14
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ HELP_PARSING = 'm <- readLines("Makefile");\
 help:           ## Show this help.
 	@Rscript -e $(HELP_PARSING)
 
-build:          ## Build the package using lucode2::buildLibrary().
-	Rscript -e 'lucode2::buildLibrary()'
+build:          ## Build the package using lucode2::buildLibrary(). You can pass the
+                ## updateType with 'make build u=3'
+	Rscript -e 'lucode2::buildLibrary(updateType = "$(u)")'
 
 check:          ## Build documentation and vignettes, run testthat tests,
                 ## and check if code etiquette is followed using lucode2::check().

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.25.5**
+R package **gms**, version **0.25.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.5, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.6, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.25.5},
+  note = {R package version 0.25.6},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -40,10 +40,17 @@ test_that("check various chooseFromList settings", {
   expect_identical(theList[choosePatternFromList(theList, pattern = "^[0-9]+$")],
                    theList[names(theList) == "Number"])
   # Test pattern search by overriding getLine, only works with 'y' because this validates the "are you sure"-question
+  # Therefore, p and f cannot be differentiated here
   with_mocked_bindings({
     expect_equal(chooseFromList(c("a", "b", "y"), userinput = "p"), "y")
     expect_equal(chooseFromList(c("a", "b", "y", "yb"), userinput = "p"), c("y", "yb"))
     expect_equal(length(chooseFromList(c("a", "b"), userinput = "p")), 0)
+    expect_equal(chooseFromList(c("a", "b", "y"), userinput = "f"), "y")
+    expect_equal(chooseFromList(c("a", "b", "y", "yb"), userinput = "f"), c("y", "yb"))
+    expect_equal(length(chooseFromList(c("a", "b"), userinput = "f")), 0)
+    expect_equal(chooseFromList(c("a", "b", "y"), userinput = "f,p"), "y")
+    expect_equal(chooseFromList(c("a", "b", "y", "yb"), userinput = "p,f"), c("y", "yb"))
+    expect_equal(length(chooseFromList(c("a", "b"), userinput = "p,f")), 0)
     },
     getLine = function() return("y")
   )


### PR DESCRIPTION
- chooseFromList always had a mode for using regular expressions
- that is extremely annoying if you want to select AR6 / remind2 variables that contain several `|`
- add fixed=TRUE mode so that user can decide whether that pattern should _not_ be interpreted as regular expression