### PR TITLE
chooseFromList: don't allow multiple=FALSE, addAllPattern=TRUE

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4997632'
+ValidationKey: '5017154'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.25.6
+version: 0.25.7
 date-released: '2023-06-14'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.25.6
+Version: 0.25.7
 Date: 2023-06-14
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -36,6 +36,7 @@
 chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPattern = TRUE,
                            returnBoolean = FALSE, multiple = TRUE, userinput = FALSE, errormessage = NULL) {
   originalList <- theList
+  addAllPattern <- addAllPattern && multiple
   booleanList <- rep(FALSE, length(originalList)) # set to FALSE
   if (is.list(theList)) booleanList <- as.list(booleanList)
   m <- paste0("\n\nPlease choose ", type, ":\n\n")
@@ -106,13 +107,13 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
       # if search by pattern is selected, ask for pattern and interpret it
       if (pattern) {
         patternid <- choosePatternFromList(originalList, type, fixed = FALSE)
-        identifier <- unique(c(patternid + 1, identifier[identifier < length(originalList) + 2]))
+        identifier <- unique(c(identifier, patternid + 1))
       }
       if (fixed) {
         patternid <- choosePatternFromList(originalList, type, fixed = TRUE)
-        identifier <- unique(c(patternid + 1, identifier[identifier < length(originalList) + 2]))
+        identifier <- unique(c(identifier, patternid + 1))
       }
-      identifier <- identifier - 1 * addAllPattern # if addAllPattern = TRUE, '1' is 'all' option
+      identifier <- identifier[identifier < length(originalList) + 2] - 1 * addAllPattern # if addAllPattern = TRUE, '1' is 'all' option
     }
   }
   booleanList[identifier] <- TRUE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.25.6**
+R package **gms**, version **0.25.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.6, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.7, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.25.6},
+  note = {R package version 0.25.7},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
- In #64 I introduced a bug if `chooseFromList` was called with `multiple = FALSE` and `addAllPattern = TRUE`, the latter being the standard setting. Obviously, it makes no sense to select "all" if you are not allowed to select multiple, so I set `addAllPattern` to `FALSE` if `multiple` is `FALSE`
- the lower lines are just sorting…
- That is how it looked like:
```
Please choose slurm mode:

That was the mess it created:

1,a: priority
2: short
3: standby
4: priority mem=8000
5: short mem=8000
6: standby mem=8000
7: priority mem=32000
8: direct
1: priority
2,p: short
3,f: standby
Uses the first option if empty.
Number or leave empty:
```