### PR TITLE
add better tests to chooseFromList

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5036676'
+ValidationKey: '5056457'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.25.8
-date-released: '2023-06-14'
+version: 0.25.9
+date-released: '2023-06-15'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.25.8
-Date: 2023-06-14
+Version: 0.25.9
+Date: 2023-06-15
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -75,7 +75,7 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
     userinput <- getLine()
   }
   # interpret userinput and perform basic checks
-  identifier <- try(eval(parse(text = paste("c(", userinput, ")"))))
+  identifier <- try(eval(parse(text = paste("c(", userinput, ")"))), silent = TRUE)
   if (! all(grepl(if (addAllPattern) "^[afp0-9,: ]*$" else "^[0-9,: ]*$", userinput)) || inherits(identifier, "try-error")) {
     err <- paste0("Try again, you have to choose some numbers. ", attr(identifier, "condition"), "\n")
     return(chooseFromList(originalList, type, userinfo, addAllPattern, returnBoolean, multiple, errormessage = err))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.25.8**
+R package **gms**, version **0.25.9**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.8, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.9, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.25.8},
+  note = {R package version 0.25.9},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -39,6 +39,24 @@ test_that("check various chooseFromList settings", {
                    c("A", "B"))
   expect_identical(theList[choosePatternFromList(theList, pattern = "^[0-9]+$")],
                    theList[names(theList) == "Number"])
+  # check whether chooseFromList identifies errors and asks user again
+  with_mocked_bindings({
+    expect_error(chooseFromList(theList, userinput = length(theList) + length(unique(names(theList))) + 3 + 1)) # 3 for all, pattern, fixed
+    expect_error(chooseFromList(theList, multiple = FALSE, userinput = length(theList) + 1))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "p"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "f"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "a"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "p"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "f"))
+    expect_error(chooseFromList(theList, userinput = "1,,"))
+    expect_error(chooseFromList(theList, userinput = "1,:3,"))
+    expect_error(chooseFromList(theList, userinput = "0"))
+    expect_error(chooseFromList(theList, userinput = "-1"))
+    expect_error(chooseFromList(theList, userinput = "1-2"))
+    },
+    getLine = function() stop("getLine should not called.")
+  )
   # Test pattern search by overriding getLine, only works with 'y' because this validates the "are you sure"-question
   # Therefore, p and f cannot be differentiated here
   with_mocked_bindings({
@@ -69,4 +87,17 @@ test_that("chooseFromList works with multiple groups", {
 test_that("chooseFromList works with no groups", {
   theList <- c("A1", "B", "C", 1, 2, "3C")
   expect_identical(unname(chooseFromList(theList, userinput = "3")), "B")
+  with_mocked_bindings({
+    expect_error(chooseFromList(theList, userinput = length(theList) + 3 + 1)) # 3 for all, pattern, fixed
+    expect_error(chooseFromList(theList, multiple = FALSE, userinput = length(theList) + 1))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "p"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "f"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "a"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "p"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "f"))
+    },
+    getLine = function() stop("getLine should not called.")
+  )
 })


### PR DESCRIPTION
- in #64, I introduces some bugs that needed fixing in #65 and #66. Make sure that does not happen again.
- chooseFromList is quite generous with errors and let the user try as often as he likes to get it right. The test now mocks `getLine` to `stop()` and so if the user is asked again, that results in an error that the tests can catch. 