### PR TITLE
if chooseFromList gets empty list, just return it

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '49067990'
+ValidationKey: '49190490'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,5 +1,3 @@
-# Run CI for R using https://eddelbuettel.github.io/r-ci/
-
 name: check
 
 on:
@@ -8,11 +6,6 @@ on:
   pull_request:
     branches: [main, master]
 
-env:
-  USE_BSPM: "true"
-  _R_CHECK_FORCE_SUGGESTS_: "false"
-  NO_BINARY_INSTALL_R_PACKAGES: 'c("madrat", "magclass", "citation", "gms", "goxygen", "GDPuc", "roxygen2")'
-
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -20,79 +13,36 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Bootstrap
-        run: |
-          sudo chown runner -R .
-          sudo locale-gen en_US.UTF-8
-          sudo add-apt-repository -y ppa:ubuntugis/ppa
-          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
-          chmod 0755 run.sh
-          ./run.sh bootstrap
-          rm -f bspm_*.tar.gz
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Enable r-universe repo, modify bspm integration
-        run: |
-          # install packages from https://pik-piam.r-universe.dev and CRAN
-          echo '
-          options(repos = c(universe = "https://pik-piam.r-universe.dev",
-                            CRAN = "https://cloud.r-project.org"))
-          ' >> .Rprofile
-          cat .Rprofile
-          # modify bspm integration to never install binary builds of PIK CRAN packages
-          sudo sed -i '/bspm::enable()/d' /etc/R/Rprofile.site
-          # need double % because of printf, %s is replaced with "$NO_BINARY_INSTALL_R_PACKAGES" (see "env:" above)
-          printf '
-          local({
-            expr <- quote({
-              if (!is.null(repos)) {
-                noBinaryInstallRPackages <- %s
-                pkgs <- c(bspm::install_sys(pkgs[!pkgs %%in%% noBinaryInstallRPackages]),
-                          pkgs[pkgs %%in%% noBinaryInstallRPackages])
-              }
-              type <- "source"
-            })
-            trace(utils::install.packages, expr, print = FALSE)
-          })
-          ' "$NO_BINARY_INSTALL_R_PACKAGES" | sudo tee --append /etc/R/Rprofile.site >/dev/null
-          cat /etc/R/Rprofile.site
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
 
-      - name: Set up Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::lucode2
+            any::covr
+            any::madrat
+            any::magclass
+            any::citation
+            any::gms
+            any::goxygen
+            any::GDPuc
+          # piam packages also available on CRAN (madrat, magclass, citation,
+          # gms, goxygen, GDPuc) will usually have an outdated binary version
+          # available; by using extra-packages we get the newest version
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-
-      - name: Cache R libraries
-        if: ${{ !env.ACT }} # skip when running locally via nektos/act
-        uses: pat-s/always-upload-cache@v3
-        with:
-          path: /usr/local/lib/R/
-          key: 3-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
-          restore-keys: |
-            3-${{ runner.os }}-usr-local-lib-R-
-
-      - name: Restore R library permissions
-        run: |
-          sudo chmod 2777 /usr/local/lib/R /usr/local/lib/R/site-library
-
-      - name: Install dependencies
-        run: |
-          ./run.sh install_aptget libhdf5-dev libharfbuzz-dev libfribidi-dev
-          ./run.sh install_all
-          ./run.sh install_r_binary covr rstudioapi
-          ./run.sh install_r lucode2
 
       - name: Install python dependencies if applicable
         run: |
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
-
-      - name: Remove bspm integration # to get rid of error when running install.packages
-        run: |
-          sudo sed -i '/  trace(utils::install.packages, expr, print = FALSE)/d' /etc/R/Rprofile.site
-          cat /etc/R/Rprofile.site
 
       - name: Verify validation key
         shell: Rscript {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9013
+    rev: v0.3.2.9019
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.25.10
-date-released: '2023-07-11'
+version: 0.25.11
+date-released: '2023-08-21'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.25.10
-Date: 2023-07-11
+Version: 0.25.11
+Date: 2023-08-21
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -36,6 +36,10 @@
 chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPattern = TRUE,
                            returnBoolean = FALSE, multiple = TRUE, userinput = FALSE, errormessage = NULL) {
   originalList <- theList
+  if (length(theList) == 0) {
+    message("No ", type, " found that might be selected, returning the empty list.")
+    return(theList)
+  }
   addAllPattern <- addAllPattern && multiple
   booleanList <- rep(FALSE, length(originalList)) # set to FALSE
   if (is.list(theList)) booleanList <- as.list(booleanList)

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -56,7 +56,7 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
     if (! is.null(groups)) {
       groupsids <- seq(length(originalList) + 1 + 1 * addAllPattern,
                        length(originalList) + length(groups) + 1 * addAllPattern)
-      theList <- c(paste0(str_pad(theList, max(nchar(originalList), 10), side = "right"), " ", names(theList)),
+      theList <- c(paste0(str_pad(paste(theList), max(nchar(originalList), 10), side = "right"), " ", names(theList)),
                    paste("Group:", groups))
       m <- c(m, paste0(str_pad("", max(nchar(originalList), 10) + nchar(length(theList) + 2) + 2, side = "right"),
                        " Group\n"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.25.10**
+R package **gms**, version **0.25.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.10, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.25.11, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.25.10},
+  note = {R package version 0.25.11},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -1,46 +1,50 @@
 context("chooseFromList test")
 
-test_that("check various chooseFromList settings", {
-  theList <- c(Letter = "A", Letter = "B", Letter = "C",
-               Number = 1, Number = 2, Number = 3)
-  expect_identical(unname(chooseFromList(theList, userinput = "3")),
-                   "B")
-  expect_identical(unname(chooseFromList(theList, multiple = FALSE, userinput = "3")),
-                   "C")
-  expect_identical(unname(chooseFromList(theList, userinput = "3,5")),
-                   c("B", "1"))
-  expect_identical(unname(chooseFromList(theList, returnBoolean = TRUE, userinput = "3,5")),
-                   c(FALSE, TRUE, FALSE, TRUE, FALSE, FALSE))
-  expect_identical(unname(chooseFromList(theList, returnBoolean = TRUE, userinput = " 3, 5   ")),
-                   c(FALSE, TRUE, FALSE, TRUE, FALSE, FALSE))
-  expect_identical(chooseFromList(theList, userinput = "1"),
-                   theList)
-  expect_identical(chooseFromList(theList, userinput = "a"),
-                   theList)
-  expect_identical(chooseFromList(theList, userinput = "a,1"),
-                   theList)
-  expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "1"),
-                   theList[1])
-  expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "  1 :  1  "),
-                   theList[1])
-  expect_identical(unname(chooseFromList(theList, userinput = "1", returnBoolean = TRUE)),
-                   rep(TRUE, length(theList)))
-  expect_identical(chooseFromList(theList, userinput = toString(length(theList) + 2)),
-                   theList[names(theList) == "Letter"])
-  expect_identical(unname(chooseFromList(theList, userinput = "")),
-                   character(0))
-  expect_identical(unname(chooseFromList(theList, returnBoolean = TRUE, userinput = "")),
-                   rep(FALSE, length(theList)))
-  expect_identical(unname(chooseFromList(as.list(theList), userinput = "1", returnBoolean = TRUE)),
-                   as.list(rep(TRUE, length(theList))))
-  expect_identical(chooseFromList(as.list(theList), userinput = "1", returnBoolean = FALSE),
-                   as.list(theList))
-  expect_identical(unname(theList[choosePatternFromList(theList, pattern = "[AB]")]),
-                   c("A", "B"))
-  expect_identical(theList[choosePatternFromList(theList, pattern = "^[0-9]+$")],
-                   theList[names(theList) == "Number"])
-  # check whether chooseFromList identifies errors and asks user again
-  with_mocked_bindings({
+with_mocked_bindings({ # fail if getLine() is called
+  test_that("check various chooseFromList settings", {
+    expect_identical(chooseFromList(NULL), NULL)
+    expect_message(chooseFromList(NULL), "returning the empty list")
+    expect_identical(chooseFromList(list()), list())
+    expect_message(chooseFromList(list()), "returning the empty list")
+    theList <- c(Letter = "A", Letter = "B", Letter = "C",
+                 Number = 1, Number = 2, Number = 3)
+    expect_identical(unname(chooseFromList(theList, userinput = "3")),
+                     "B")
+    expect_identical(unname(chooseFromList(theList, multiple = FALSE, userinput = "3")),
+                     "C")
+    expect_identical(unname(chooseFromList(theList, userinput = "3,5")),
+                     c("B", "1"))
+    expect_identical(unname(chooseFromList(theList, returnBoolean = TRUE, userinput = "3,5")),
+                     c(FALSE, TRUE, FALSE, TRUE, FALSE, FALSE))
+    expect_identical(unname(chooseFromList(theList, returnBoolean = TRUE, userinput = " 3, 5   ")),
+                     c(FALSE, TRUE, FALSE, TRUE, FALSE, FALSE))
+    expect_identical(chooseFromList(theList, userinput = "1"),
+                     theList)
+    expect_identical(chooseFromList(theList, userinput = "a"),
+                     theList)
+    expect_identical(chooseFromList(theList, userinput = "a,1"),
+                     theList)
+    expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "1"),
+                     theList[1])
+    expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "  1 :  1  "),
+                     theList[1])
+    expect_identical(unname(chooseFromList(theList, userinput = "1", returnBoolean = TRUE)),
+                     rep(TRUE, length(theList)))
+    expect_identical(chooseFromList(theList, userinput = toString(length(theList) + 2)),
+                     theList[names(theList) == "Letter"])
+    expect_identical(unname(chooseFromList(theList, userinput = "")),
+                     character(0))
+    expect_identical(unname(chooseFromList(theList, returnBoolean = TRUE, userinput = "")),
+                     rep(FALSE, length(theList)))
+    expect_identical(unname(chooseFromList(as.list(theList), userinput = "1", returnBoolean = TRUE)),
+                     as.list(rep(TRUE, length(theList))))
+    expect_identical(chooseFromList(as.list(theList), userinput = "1", returnBoolean = FALSE),
+                     as.list(theList))
+    expect_identical(unname(theList[choosePatternFromList(theList, pattern = "[AB]")]),
+                     c("A", "B"))
+    expect_identical(theList[choosePatternFromList(theList, pattern = "^[0-9]+$")],
+                     theList[names(theList) == "Number"])
+    # check whether chooseFromList identifies errors and asks user again
     expect_error(chooseFromList(theList, userinput = length(theList) + length(unique(names(theList))) + 3 + 1)) # 3 for all, pattern, fixed
     expect_error(chooseFromList(theList, multiple = FALSE, userinput = length(theList) + 1))
     expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
@@ -54,12 +58,39 @@ test_that("check various chooseFromList settings", {
     expect_error(chooseFromList(theList, userinput = "0"))
     expect_error(chooseFromList(theList, userinput = "-1"))
     expect_error(chooseFromList(theList, userinput = "1-2"))
-    },
-    getLine = function() stop("getLine should not called.")
-  )
-  # Test pattern search by overriding getLine, only works with 'y' because this validates the "are you sure"-question
-  # Therefore, p and f cannot be differentiated here
-  with_mocked_bindings({
+  })
+
+  test_that("chooseFromList works with multiple groups", {
+    theList <- c("Letter,Number" = "A1", Letter = "B", Letter = "C",
+                 Number = 1, Number = 2, "Number,Letter" = "3C")
+    expect_identical(unname(chooseFromList(theList, userinput = "3")),
+                     "B")
+    expect_identical(chooseFromList(theList, userinput = toString(length(theList) + 2)),
+                     theList[names(theList) %in% c("Letter", "Letter,Number", "Number,Letter")])
+  })
+
+  test_that("chooseFromList works with no groups", {
+    theList <- c("A1", "B", "C", 1, 2, "3C")
+    expect_identical(unname(chooseFromList(theList, userinput = "3")), "B")
+    expect_error(chooseFromList(theList, userinput = length(theList) + 3 + 1)) # 3 for all, pattern, fixed
+    expect_error(chooseFromList(theList, multiple = FALSE, userinput = length(theList) + 1))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "p"))
+    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "f"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "a"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "p"))
+    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "f"))
+  })
+
+  }, # end of with_mocked_bindings
+  getLine = function() stop("getLine should not called.")
+)
+
+with_mocked_bindings({
+  test_that("test pattern search with user typing y", {
+    # Test pattern search by overriding getLine, only works with 'y' because this validates the "are you sure"-question
+    # Therefore, p and f cannot be differentiated here
     expect_equal(chooseFromList(c("a", "b", "y"), userinput = "p"), "y")
     expect_equal(chooseFromList(c("a", "b", "y", "yb"), userinput = "p"), c("y", "yb"))
     expect_equal(length(chooseFromList(c("a", "b"), userinput = "p")), 0)
@@ -70,34 +101,7 @@ test_that("check various chooseFromList settings", {
     expect_equal(chooseFromList(c("a", "b", "y", "yb"), userinput = "p,f"), c("y", "yb"))
     expect_equal(length(chooseFromList(c("a", "b"), userinput = "p,f")), 0)
     expect_equal(length(chooseFromList(setNames(c("a", "b", "c"), c("L", "L", "y")), userinput = "p,f")), 0)
-    },
-    getLine = function() return("y")
-  )
-})
-
-test_that("chooseFromList works with multiple groups", {
-  theList <- c("Letter,Number" = "A1", Letter = "B", Letter = "C",
-               Number = 1, Number = 2, "Number,Letter" = "3C")
-  expect_identical(unname(chooseFromList(theList, userinput = "3")),
-                   "B")
-  expect_identical(chooseFromList(theList, userinput = toString(length(theList) + 2)),
-                   theList[names(theList) %in% c("Letter", "Letter,Number", "Number,Letter")])
-})
-
-test_that("chooseFromList works with no groups", {
-  theList <- c("A1", "B", "C", 1, 2, "3C")
-  expect_identical(unname(chooseFromList(theList, userinput = "3")), "B")
-  with_mocked_bindings({
-    expect_error(chooseFromList(theList, userinput = length(theList) + 3 + 1)) # 3 for all, pattern, fixed
-    expect_error(chooseFromList(theList, multiple = FALSE, userinput = length(theList) + 1))
-    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
-    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "a"))
-    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "p"))
-    expect_error(chooseFromList(theList, addAllPattern = FALSE, userinput = "f"))
-    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "a"))
-    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "p"))
-    expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "f"))
-    },
-    getLine = function() stop("getLine should not called.")
-  )
-})
+  })
+  }, # end of with_mocked_bindings
+  getLine = function() return("y")
+)

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -2,10 +2,12 @@ context("chooseFromList test")
 
 with_mocked_bindings({ # fail if getLine() is called
   test_that("check various chooseFromList settings", {
-    expect_identical(chooseFromList(NULL), NULL)
-    expect_message(chooseFromList(NULL), "returning the empty list")
-    expect_identical(chooseFromList(list()), list())
-    expect_message(chooseFromList(list()), "returning the empty list")
+    zerolength <- list(NULL, logical(0), character(0), numeric(0), list(), a = NULL)
+    for (z in zerolength) {
+      expect_identical(chooseFromList(z), z)
+      expect_message(chooseFromList(z), "returning the empty list")
+    }
+    expect_identical(chooseFromList(list(n = NULL), userinput = "a"), list(n = NULL))
     theList <- c(Letter = "A", Letter = "B", Letter = "C",
                  Number = 1, Number = 2, Number = 3)
     expect_identical(unname(chooseFromList(theList, userinput = "3")),
@@ -58,6 +60,7 @@ with_mocked_bindings({ # fail if getLine() is called
     expect_error(chooseFromList(theList, userinput = "0"))
     expect_error(chooseFromList(theList, userinput = "-1"))
     expect_error(chooseFromList(theList, userinput = "1-2"))
+    expect_error(chooseFromList(theList, multiple = FALSE, userinput = "1:2"))
   })
 
   test_that("chooseFromList works with multiple groups", {
@@ -81,6 +84,7 @@ with_mocked_bindings({ # fail if getLine() is called
     expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "a"))
     expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "p"))
     expect_error(chooseFromList(theList, multiple = FALSE, addAllPattern = TRUE, userinput = "f"))
+    expect_error(chooseFromList(theList, multiple = FALSE, userinput = "1:2"))
   })
 
   }, # end of with_mocked_bindings


### PR DESCRIPTION
1. `chooseFromList(NULL)` or `chooseFromList(list())` now directly returns the empty list instead of this nonsense where you cannot actually select anything meaningful:
```
Please choose runs to be used for output generation:

1,a: all
2,p: Search pattern by regular expression...
3,f: Search by fixed pattern...
```

2. I use the `with_mocked_bindings` binding `getLine` to `stop()` or some specific value now everywhere in chooseFromList tests to avoid that the script hangs on such a call instead of failing. The only substantive change in the test script is adding:
```
    zerolength <- list(NULL, logical(0), character(0), numeric(0), list(), a = NULL)
    for (z in zerolength) {
      expect_identical(chooseFromList(z), z)
      expect_message(chooseFromList(z), "returning the empty list")
    }
```