### PR TITLE
add extrapage attribute to dummy model

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5174788'
+ValidationKey: '5176103'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5145418'
+ValidationKey: '5174788'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
+            gamstransfer=?ignore
             any::lucode2
             any::covr
             any::madrat
@@ -56,6 +57,8 @@ jobs:
 
       - name: Test coverage
         shell: Rscript {0}
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
+          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: '^tests/testthat/_snaps/.*$'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-case-conflict
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2.9019
+    rev: v0.3.2.9025
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
 version: 0.26.3
-date-released: '2023-11-15'
+date-released: '2023-11-20'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.26.2
-date-released: '2023-10-09'
+version: 0.26.3
+date-released: '2023-11-15'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.26.2
-Date: 2023-10-09
+Version: 0.26.3
+Date: 2023-11-15
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
 Version: 0.26.3
-Date: 2023-11-15
+Date: 2023-11-20
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.26.2**
+R package **gms**, version **0.26.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,16 +43,16 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.26.2, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pfl?ger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.26.3, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {gms: 'GAMS' Modularization Support Package},
-  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
+  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pfl?ger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.26.2},
+  note = {R package version 0.26.3},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pfl?ger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.26.3, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.26.3, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Manual{,
   title = {gms: 'GAMS' Modularization Support Package},
-  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pfl?ger and Oliver Richters},
+  author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
   note = {R package version 0.26.3},
   doi = {10.5281/zenodo.4390032},

--- a/inst/dummymodel/main.gms
+++ b/inst/dummymodel/main.gms
@@ -19,3 +19,10 @@ $setglobal Rmodule  withr
 $include "./core/sets.gms"
 $include "./core/core.gms"
 $batinclude "./modules/include.gms" calculations
+
+
+*' @title extrapage="settings"
+*' Settings
+
+*' @description extrapage="settings"
+*' We might want to move some documentation to a separate page called Settings.

--- a/inst/dummymodel/main.gms
+++ b/inst/dummymodel/main.gms
@@ -20,7 +20,7 @@ $include "./core/sets.gms"
 $include "./core/core.gms"
 $batinclude "./modules/include.gms" calculations
 
-*' @title extrapage="settings"
+*' @title{extrapage: "settings"}
 *' Settings
-*' @description extrapage="settings"
+*' @description{extrapage: "settings"}
 *' We might want to move some documentation to a separate page called Settings.

--- a/inst/dummymodel/main.gms
+++ b/inst/dummymodel/main.gms
@@ -20,9 +20,7 @@ $include "./core/sets.gms"
 $include "./core/core.gms"
 $batinclude "./modules/include.gms" calculations
 
-
 *' @title extrapage="settings"
 *' Settings
-
 *' @description extrapage="settings"
 *' We might want to move some documentation to a separate page called Settings.

--- a/inst/dummymodel/modules/02_crazymodule/complex/realization.gms
+++ b/inst/dummymodel/modules/02_crazymodule/complex/realization.gms
@@ -7,3 +7,10 @@
 *####################### R SECTION START (PHASES) ##############################
 $Ifi "%phase%" == "calculations" $include "./modules/02_crazymodule/complex/calculations.gms"
 *######################## R SECTION END (PHASES) ###############################
+
+
+*' @description extrapage="crazy"
+*' The crazy module deserves a mention on an extra page!
+
+*' @limitations extrapage="crazy"
+*' The sky is the limit!

--- a/inst/dummymodel/modules/02_crazymodule/complex/realization.gms
+++ b/inst/dummymodel/modules/02_crazymodule/complex/realization.gms
@@ -9,8 +9,8 @@ $Ifi "%phase%" == "calculations" $include "./modules/02_crazymodule/complex/calc
 *######################## R SECTION END (PHASES) ###############################
 
 
-*' @description extrapage="crazy"
+*' @description{extrapage: "crazy"}
 *' The crazy module deserves a mention on an extra page!
 
-*' @limitations extrapage="crazy"
+*' @limitations{extrapage: "crazy"}
 *' The sky is the limit!

--- a/inst/extdata/full.gms
+++ b/inst/extdata/full.gms
@@ -151,3 +151,8 @@ Execute.checkErrorLevel "Rscript modules/03_Rmodule/withr/run_calculations.R";
 *###################### R SECTION END (MODULETYPES) ############################
 *######################## R SECTION END (MODULES) ##############################
 $offrecurse
+
+*' @title extrapage="settings"
+*' Settings
+*' @description extrapage="settings"
+*' We might want to move some documentation to a separate page called Settings.

--- a/inst/extdata/full.gms
+++ b/inst/extdata/full.gms
@@ -152,7 +152,7 @@ Execute.checkErrorLevel "Rscript modules/03_Rmodule/withr/run_calculations.R";
 *######################## R SECTION END (MODULES) ##############################
 $offrecurse
 
-*' @title extrapage="settings"
+*' @title{extrapage: "settings"}
 *' Settings
-*' @description extrapage="settings"
+*' @description{extrapage: "settings"}
 *' We might want to move some documentation to a separate page called Settings.

--- a/inst/extdata/full_embed.gms
+++ b/inst/extdata/full_embed.gms
@@ -159,3 +159,8 @@ Execute.checkErrorLevel "Rscript modules_03_Rmodule_withr_run_calculations.R";
 *###################### R SECTION END (MODULETYPES) ############################
 *######################## R SECTION END (MODULES) ##############################
 $offrecurse
+
+*' @title extrapage="settings"
+*' Settings
+*' @description extrapage="settings"
+*' We might want to move some documentation to a separate page called Settings.

--- a/inst/extdata/full_embed.gms
+++ b/inst/extdata/full_embed.gms
@@ -160,7 +160,7 @@ Execute.checkErrorLevel "Rscript modules_03_Rmodule_withr_run_calculations.R";
 *######################## R SECTION END (MODULES) ##############################
 $offrecurse
 
-*' @title extrapage="settings"
+*' @title{extrapage: "settings"}
 *' Settings
-*' @description extrapage="settings"
+*' @description{extrapage: "settings"}
 *' We might want to move some documentation to a separate page called Settings.

--- a/man/gms-package.Rd
+++ b/man/gms-package.Rd
@@ -27,7 +27,7 @@ Authors:
   \item Felicitas Beier
   \item Johannes Koch
   \item Lavinia Baumstark
-  \item Mika Pfl<U+00FC>ger
+  \item Mika Pflüger
   \item Oliver Richters
 }
 

--- a/man/gms-package.Rd
+++ b/man/gms-package.Rd
@@ -27,7 +27,7 @@ Authors:
   \item Felicitas Beier
   \item Johannes Koch
   \item Lavinia Baumstark
-  \item Mika Pflüger
+  \item Mika Pfl<U+00FC>ger
   \item Oliver Richters
 }
 


### PR DESCRIPTION
The dummy model is extended to use the extrapage attribute, so it can be included in the unit tests of https://github.com/pik-piam/goxygen/pull/22