### PR TITLE
don't add empty realizations to main module files

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '5511520'
+ValidationKey: '5708360'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.28.0
+version: 0.29.0
 date-released: '2023-11-23'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.28.0
+Version: 0.29.0
 Date: 2023-11-23
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -47,7 +47,8 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
     stop("Could not find model main file. Neither main.gms nor magpie.gms do exist!")
   }
 
-  #connect whole code to one object by replacing $incude commands with
+  code <- c("", code, "") # includes in first or last line let repeat statement run infinitely
+  #connect whole code to one object by replacing $include commands with
   #corresponding code (.csv, .cs2 includes and batincludes are excluded)
   repeat {
     i <- grep("^\\$include", code)[1]
@@ -114,10 +115,10 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
       t <- types[ti]
       code <- NULL
       for (phase in phases) {
-        if (file.exists(path(".", modulepath, module, t, phase, ftype = "gms"))) {
+        if (file.exists(path(modelpath, modulepath, module, t, phase, ftype = "gms"))) {
           if (verbose) message(module, " ", t, ": ", phase, " is used")
           code <- c(code, paste("$Ifi \"%phase%\" == \"", phase, "\" $include \"",
-                    path(".", modulepath, module, t, phase, ftype = "gms"), "\"", sep = ""))
+                    path(modelpath, modulepath, module, t, phase, ftype = "gms"), "\"", sep = ""))
         } else if (verbose) message(module, " ", t, ": ", phase, "is not used")
       }
       replace_in_file(realizationGMSpaths[ti], code, subject = "PHASES")

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -76,8 +76,8 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
   fullmodulepath <- path(modelpath, modulepath)
   modules        <- getModules(fullmodulepath)[, "folder"]
   moduleGMSpathsAll <- switch(version,
-                         "1" = path(".", modulepath, modules, modules, ftype = "gms"),
-                         "2" = path(".", modulepath, modules, "module", ftype = "gms"))
+                         "1" = path(modelpath, modulepath, modules, modules, ftype = "gms"),
+                         "2" = path(modelpath, modulepath, modules, "module", ftype = "gms"))
   # excludes modules that have no gms file
   if (! all(file.exists(moduleGMSpathsAll))) {
     warning("Missing module gms files: ",
@@ -97,8 +97,15 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
     #remove reserved module type names
     types <- setdiff(types, getOption("gms_reserved_types"))
     realizationGMSpaths <- switch(version,
-                           "1" = path(".", modulepath, module, types, ftype = "gms"),
-                           "2" = path(".", modulepath, module, types, "realization", ftype = "gms"))
+                           "1" = path(modelpath, modulepath, module, types, ftype = "gms"),
+                           "2" = path(modelpath, modulepath, module, types, "realization", ftype = "gms"))
+    emptyrealization <- ! file.exists(realizationGMSpaths)
+    if (any(emptyrealization)) {
+      warning("For module ", module, ", the following realizations lack their main gms file and cannot be used: ",
+              paste(types[emptyrealization], collapse = ", "))
+    }
+    types <- types[! emptyrealization]
+    realizationGMSpaths <- realizationGMSpaths[! emptyrealization]
     code <- paste0("$Ifi \"%", substring(module, 4), "%\" == \"", types, "\" $include \"", realizationGMSpaths, "\"")
     replace_in_file(moduleGMSpaths[m], code, subject = "MODULETYPES")
 
@@ -113,17 +120,13 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
                     path(".", modulepath, module, t, phase, ftype = "gms"), "\"", sep = ""))
         } else if (verbose) message(module, " ", t, ": ", phase, "is not used")
       }
-      if (file.exists(realizationGMSpaths[ti])) {
-        replace_in_file(realizationGMSpaths[ti], code, subject = "PHASES")
-      } else {
-        warning(realizationGMSpaths[ti], " not found, this realization cannot be used!")
-      }
+      replace_in_file(realizationGMSpaths[ti], code, subject = "PHASES")
     }
   }
 
   ############# ADD MODULE INFO IN SETS  ###################### START ##########################################
 
-  if (length(grep("module2realisation", readLines(path(modelpath, "core/sets.gms")))) > 0) {
+  if (length(grep("module2realisation", readLines(path(modelpath, "core", "sets.gms")))) > 0) {
     content <- NULL
     modification_warning <- c(
       '*** THIS CODE IS CREATED AUTOMATICALLY, DO NOT MODIFY THESE LINES DIRECTLY',
@@ -136,7 +139,7 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
     content <- c(content, '', '      module2realisation(modules,*) "mapping of modules and active realisations" /')
     content <- c(content, paste0("       ", moduleNames, " . %", moduleNames, "%"))
     content <- c(content, '      /', ';')
-    replace_in_file("core/sets.gms", content, "MODULES", comment = "***")
+    replace_in_file(path(modelpath, "core", "sets.gms"), content, "MODULES", comment = "***")
 
 
   ############# ADD MODULE INFO IN SETS  ###################### END ############################################

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.28.0**
+R package **gms**, version **0.29.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.28.0, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2023). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.29.0, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2023},
-  note = {R package version 0.28.0},
+  note = {R package version 0.29.0},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-update_modules_embedding.R
+++ b/tests/testthat/test-update_modules_embedding.R
@@ -1,0 +1,30 @@
+test_that("update_modules_embedding", {
+  modelpath <- tempdir()
+  writeLines("code in main.gms", file.path(modelpath, "main.gms"))
+  dir.create(file.path(modelpath, "core"))
+  writeLines(c("***######################## R SECTION START (MODULES) ###############################",
+               "module2realisation",
+               "***######################### R SECTION END (MODULES) ################################"),
+             file.path(modelpath, "core", "sets.gms"))
+  modulepath <- file.path(modelpath, "modules") 
+  dir.create(modulepath)
+  writeLines(c("*######################## R SECTION START (MODULES) ############################",
+               "*######################## R SECTION END (MODULES) ##############################"),
+             file.path(modulepath, "include.gms"))
+  module21path <- file.path(modulepath, "21_testmodule")
+  dir.create(module21path)
+  writeLines(c("*###################### R SECTION START (MODULETYPES) ##########################",
+               "*###################### R SECTION END (MODULETYPES) ############################"),
+             file.path(module21path, "module.gms"))
+  dir.create(file.path(module21path, "empty"))
+  dir.create(file.path(module21path, "works"))
+  writeLines(c("*####################### R SECTION START (PHASES) ##############################",
+               "*######################## R SECTION END (PHASES) ###############################"),
+             file.path(module21path, "works", "realization.gms"))
+  expect_warning(update_modules_embedding(modelpath = modelpath, modulepath = "modules/",
+                                          includefile = "modules/include.gms", verbose = FALSE), "empty")
+  expect_true(any(grepl("testmodule", readLines(file.path(modelpath, "core", "sets.gms"), warn = FALSE))))
+  expect_true(any(grepl("works", readLines(file.path(module21path, "module.gms"), warn = FALSE))))
+  expect_false(any(grepl("empty", readLines(file.path(module21path, "module.gms"), warn = FALSE))))
+})
+

--- a/tests/testthat/test-update_modules_embedding.R
+++ b/tests/testthat/test-update_modules_embedding.R
@@ -1,6 +1,8 @@
-test_that("update_modules_embedding", {
+test_that("update_modules_embedding test", {
   modelpath <- tempdir()
-  writeLines("code in main.gms", file.path(modelpath, "main.gms"))
+  writeLines(c('$include    "./core/sets.gms";',
+               '$batinclude "./modules/include.gms"    sets'),
+             file.path(modelpath, "main.gms"))
   dir.create(file.path(modelpath, "core"))
   writeLines(c("***######################## R SECTION START (MODULES) ###############################",
                "module2realisation",
@@ -21,10 +23,14 @@ test_that("update_modules_embedding", {
   writeLines(c("*####################### R SECTION START (PHASES) ##############################",
                "*######################## R SECTION END (PHASES) ###############################"),
              file.path(module21path, "works", "realization.gms"))
+  writeLines("some GAMS code",
+             file.path(module21path, "works", "sets.gms"))
   expect_warning(update_modules_embedding(modelpath = modelpath, modulepath = "modules/",
                                           includefile = "modules/include.gms", verbose = FALSE), "empty")
   expect_true(any(grepl("testmodule", readLines(file.path(modelpath, "core", "sets.gms"), warn = FALSE))))
+  expect_true(any(grepl("21_testmodule", readLines(file.path(modulepath, "include.gms"), warn = FALSE))))
   expect_true(any(grepl("works", readLines(file.path(module21path, "module.gms"), warn = FALSE))))
   expect_false(any(grepl("empty", readLines(file.path(module21path, "module.gms"), warn = FALSE))))
+  expect_true(any(grepl("sets", readLines(file.path(module21path, "works", "realization.gms"), warn = FALSE))))
 })
 


### PR DESCRIPTION
- if a realization is deleted in the repo, often the `input` folder remains in the clones, containing the input files that are not version-controlled
- `update_modules_embedding` then adds that empty realization to `module.gms`, but warns it cannot be used
- After this PR: Warn that it cannot be used, and therefore don't add it to `module.gms`
- added a small test that let me find several errors:
  - `modelpath` was not used consistently, often assuming `.`
  - if the first line of `main.gms` contains an include, the script ran infinitely