### PR TITLE
codeCheck: edit not_used.txt only if interactive; auto-remove stuff never declared

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6054822'
+ValidationKey: '6075530'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.30.6
-date-released: '2024-03-05'
+version: 0.30.7
+date-released: '2024-03-08'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.30.6
-Date: 2024-03-05
+Version: 0.30.7
+Date: 2024-03-08
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -205,10 +205,12 @@ codeCheck <- function(path = ".",
 
   # mark instances only showing up in not_used, but are never declared
   notDeclared <- ! gams$not_used[, "name"] %in% gams$declarations[, "names"]
-  interfacesOnlyNotused <- as.list(setNames(gams$not_used[, "name"],
-                                   gsub("\\..*$", "", rownames(gams$not_used)))[notDeclared])
-  gams$not_used <- gams$not_used[! notDeclared, ]
-
+  interfacesOnlyNotused <- list()
+  if (length(notDeclared) > 0 && any(notDeclared)) {
+    interfacesOnlyNotused <- as.list(setNames(gams$not_used[, "name"],
+                                     gsub("\\..*$", "", rownames(gams$not_used)))[notDeclared])
+    gams$not_used <- gams$not_used[! notDeclared, ]
+  }
 
   if (returnDebug) {
     gamsBackup <- gams

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -158,7 +158,7 @@ codeCheck <- function(path = ".",
         w <- .warning(i,
                       " appears only in \"",
                       mod,
-                      "\" even though it is supposed to be an interface (perhaps only in not_used.txt?)!",
+                      "\" even though it is supposed to be an interface!",
                       w = w)
       } else {
         whereDeclared <- unique(sub("\\.[^\\.]*$", "", rownames(gams$declarations)[gams$declarations[, 1] == i]))
@@ -198,16 +198,23 @@ codeCheck <- function(path = ".",
 
   modulesInfo <- getModules(paste0(path, "/", modulepath))
 
+  # warnings
+  w <- NULL
+
   gams <- .collectData(path = path, modulepath = modulepath, coreFiles = core_files, modulesInfo = modulesInfo)
+
+  # mark instances only showing up in not_used, but are never declared
+  notDeclared <- ! gams$not_used[, "name"] %in% gams$declarations[, "names"]
+  interfacesOnlyNotused <- as.list(setNames(gams$not_used[, "name"],
+                                   gsub("\\..*$", "", rownames(gams$not_used)))[notDeclared])
+  gams$not_used <- gams$not_used[! notDeclared, ]
+
 
   if (returnDebug) {
     gamsBackup <- gams
   }
 
   .emitTimingMessage(" Finished data collection...", ptm)
-
-  # warnings
-  w <- NULL
 
   ret <- .checkNamingConventions(gams = gams, w = w)
   gams <- ret$gams
@@ -293,7 +300,6 @@ codeCheck <- function(path = ".",
   }
 
   # do interfaces appear only in not_used.txt files of a module?
-  interfacesOnlyNotused <- list()
   for (m in names(interfaceInfo)) {
     r <- grep(paste("^", m, "(\\.|$)", sep = ""), dimnames(ap$appearance)[[2]])
     for (v in interfaceInfo[[m]]) {
@@ -302,29 +308,37 @@ codeCheck <- function(path = ".",
       }
     }
   }
-  if (length(interfacesOnlyNotused) > 0) {
-    .emitTimingMessage(" Cleanup not_used.txt...", ptm)
-    for (i in seq_along(interfacesOnlyNotused)) {
-      m <- names(interfacesOnlyNotused[i])
-      r <- grep(paste("^", m, "(\\.|$)", sep = ""), dimnames(ap$appearance)[[2]])
-      v <- interfacesOnlyNotused[[i]]
-      notUsedGlob <- paste(path, modulepath, paste0("[0-9]*_", m), "*/not_used.txt", sep = "/")
-      notUsedPath <- Sys.glob(notUsedGlob)
-      for (n in notUsedPath) {
-        comment <- grep("^#", readLines(n), value = TRUE)
-        tmp <- read.csv(n, stringsAsFactors = FALSE, comment.char = "#")
-        tmp <- tmp[tmp$name != v, ]
-        writeLines(c(comment, paste(colnames(tmp), collapse = ",")), n)
-        write.table(tmp, n, sep = ",", quote = FALSE, row.names = FALSE, append = TRUE, col.names = FALSE)
-      }
-      ap$appearance[v, r] <- 0
-      message("'", v, "' has been removed as interface and has been deleted from all ",
-              length(notUsedPath), " not_used.txt files of module '", m, "'!\n")
-    }
 
-    # changes in not_used.txt require repeating the interface check
-    ret <- .getInterfaceInfo(ap = ap, gams = gams, w = w)
-    w <- ret$w
+  if (length(interfacesOnlyNotused) > 0) {
+    if (! isTRUE(interactive)) {
+      w <- .warning(paste(unique(interfacesOnlyNotused), collapse = ", "),
+                    " was never declared, but exists only in not_used.txt of ",
+                    paste(unique(names(interfacesOnlyNotused)), collapse = ", "),
+                    w = w)
+    } else {
+      .emitTimingMessage(" Cleanup not_used.txt...", ptm)
+      for (i in seq_along(interfacesOnlyNotused)) {
+        m <- names(interfacesOnlyNotused[i])
+        r <- grep(paste("^", m, "(\\.|$)", sep = ""), dimnames(ap$appearance)[[2]])
+        v <- interfacesOnlyNotused[[i]]
+        notUsedGlob <- paste(path, modulepath, paste0("[0-9]*_", m), "*/not_used.txt", sep = "/")
+        notUsedPath <- Sys.glob(notUsedGlob)
+        for (n in notUsedPath) {
+          comment <- grep("^#", readLines(n), value = TRUE)
+          tmp <- read.csv(n, stringsAsFactors = FALSE, comment.char = "#")
+          tmp <- tmp[tmp$name != v, ]
+          writeLines(c(comment, paste(colnames(tmp), collapse = ",")), n)
+          write.table(tmp, n, sep = ",", quote = FALSE, row.names = FALSE, append = TRUE, col.names = FALSE)
+        }
+        if (v %in% rownames(ap$appearance)) ap$appearance[v, r] <- 0
+        message("'", v, "' has been removed as interface and has been deleted from all ",
+                length(notUsedPath), " not_used.txt files of module '", m, "'!\n")
+      }
+
+      # changes in not_used.txt require repeating the interface check
+      ret <- .getInterfaceInfo(ap = ap, gams = gams, w = w)
+      w <- ret$w
+    }
   }
 
   # are all interfaces of a module addressed in all of its realizations?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.30.6**
+R package **gms**, version **0.30.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.30.6, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.30.7, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.30.6},
+  note = {R package version 0.30.7},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
- Adjust not_used.txt files only in `interactive = TRUE` mode
- Avoid that the interactive scripts wants to add things that were never declared to many not_used.txt -> close https://github.com/pik-piam/gms/issues/68
- Improve warnings in this case
- it is recommended to compare files with whitespace = 1 mode: https://github.com/pik-piam/gms/pull/92/files?w=1

### Example

What happens if you add `cm_NDC_version`, which is a switch name but has no GAMS definition, to `modules/46_carbonpriceRegi/netZero/not_used.txt` in remindmodel? 

In the following, irrelevant stuff shortened with `[...]`:

Old with `interactive = FALSE`. While the first warning makes sense, the three others are completely misleading.
```
 Running codeCheck...
[...]
 Switch Appearance check done...        (time elapsed:  70.92)
 Interface collection and check done... (time elapsed:  71.07)
 Input folder check done...             (time elapsed:  71.08)
 Description check done...              (time elapsed:  71.08)
Error in `gms::codeCheck()`:
! codeCheck returned warnings. Fix warnings to proceed!
Backtrace:
    ▆
 1. └─gms::codeCheck(strict = TRUE)
Warning messages:
1: Could not find any declaration for cm_NDC_version
2: 'cm_NDC_version' is not addressed in all realizations of module 'carbonprice'! (diffCurvPhaseIn2Lin=0, exogenous=0, expoLinear=0, exponential=0, linear=0, NDC=1, none=0, NPi=0,
temperatureNotToExceed=0) (0 = missing, 1 = in code, 2 = in not_used.txt)
3: 'cm_NDC_version' is not addressed in all realizations of module 'carbonpriceRegi'! (NDC=1, netZero=2, none=0) (0 = missing, 1 = in code, 2 = in not_used.txt)
4: 'cm_NDC_version' is not addressed in all realizations of module 'techpol'! (coalPhaseout=0, coalPhaseoutRegional=0, CombLowCandCoalPO=0, lowCarbonPush=0, NDC=1, NDCplus=1, NPi2018=1,
none=0) (0 = missing, 1 = in code, 2 = in not_used.txt)
Execution halted
make: *** [Makefile:67: check] Error 1
```

Old with `interactive = TRUE`. Asks many questions, if you accept them it adds the switch to many not_used.txt where they don't belong, and then at the end finally tells you the actual problem.
```
 Running codeCheck...
[...]
 Switch Appearance check done...        (time elapsed:  71.05)
In module 'carbonprice', 'cm_NDC_version' is not addressed in those 8 realizations: diffCurvPhaseIn2Lin, exogenous, expoLinear, exponential, linear, none, NPi, temperatureNotToExceed.
If you are sure that it does not need to be addressed at all you can add this to 'not_used.txt'.
Type the reason why it does not need to be addressed, or type 'n' if it actually needs to be addressed in the code.
whatever reason
In module 'carbonpriceRegi', 'cm_NDC_version' is not addressed in those 1 realizations: none.
If you are sure that it does not need to be addressed at all you can add this to 'not_used.txt'.
Type the reason why it does not need to be addressed, or type 'n' if it actually needs to be addressed in the code.
whatever reason
In module 'techpol', 'cm_NDC_version' is not addressed in those 5 realizations: coalPhaseout, coalPhaseoutRegional, CombLowCandCoalPO, lowCarbonPush, none.
If you are sure that it does not need to be addressed at all you can add this to 'not_used.txt'.
Type the reason why it does not need to be addressed, or type 'n' if it actually needs to be addressed in the code.
whatever reason
 Interface collection and check done... (time elapsed: 110.71)
 Input folder check done...             (time elapsed: 110.72)
 Description check done...              (time elapsed: 110.72)
Error in `gms::codeCheck()`:
! codeCheck returned warnings. Fix warnings to proceed!
Backtrace:
    ▆
 1. └─gms::codeCheck(strict = TRUE, interactive = TRUE)
Warning message:
Could not find any declaration for cm_NDC_version
Execution halted
make: *** [Makefile:72: check-fix] Error 1
```

New with `interactive = FALSE`: Just one straight warning.
```
 Running codeCheck...
[...]
 Switch Appearance check done...        (time elapsed:  73.59)
 Interface collection and check done... (time elapsed:  73.71)
 Input folder check done...             (time elapsed:  73.72)
 Description check done...              (time elapsed:  73.72)
Error in `gms::codeCheck()`:
! codeCheck returned warnings. Fix warnings to proceed!
Backtrace:
    ▆
 1. └─gms::codeCheck(strict = TRUE)
Warning message:
cm_NDC_version was never declared, but exists only in not_used.txt of carbonpriceRegi
Execution halted
make: *** [Makefile:67: check] Error 1
```

New with `interactive = TRUE`. As the case is obvious, doesn't even ask.
```
 Running codeCheck...
[...]
 Switch Appearance check done...        (time elapsed:  67.26)
 Cleanup not_used.txt...                (time elapsed:  67.34)
'cm_NDC_version' has been removed as interface and has been deleted from all 3 not_used.txt files of module 'carbonpriceRegi'!

 Interface collection and check done... (time elapsed:  67.46)
 Input folder check done...             (time elapsed:  67.47)
 Description check done...              (time elapsed:  67.47)
 All codeCheck tests passed!
```