### PR TITLE
remove $$-expressions from declarations

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6075530'
+ValidationKey: '6111336'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.30.7
-date-released: '2024-03-08'
+version: 0.30.8
+date-released: '2024-04-29'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.30.7
-Date: 2024-03-08
+Version: 0.30.8
+Date: 2024-04-29
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", role = c("aut","cre")),
              person("David", "Klein", role = "aut"),
              person("Anastasis", "Giannousakis", role = "aut"),

--- a/R/readDeclarations.R
+++ b/R/readDeclarations.R
@@ -47,7 +47,7 @@ readDeclarations <- function(file,
       # remove ;
       tmp <- sub(";", "", tmp)
       # remove $-expressions
-      tmp <- sub("^\\$.*", "", tmp)
+      tmp <- sub("^(\\$|[[:space:]]*\\$\\$).*", "", tmp)
       # remove type name
       tmp <- sub(paste0("^[ \\t]*", t, "[^ \\t]*"), "", tmp, ignore.case = TRUE)
       # remove "/ xyz /" entries

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.30.7**
+R package **gms**, version **0.30.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.30.7, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.30.8, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.30.7},
+  note = {R package version 0.30.8},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
Consider this GAMS code
```
Parameter
  f_foo(x)   "description"
  /
    $$ondelim
    $$include "./some/file/to/read.csv";
    $$offdelim
  /
;
```
for which `codeCheck()` reports
```
 codeCheck reported code inconsistencies. Please fix the given warnings!
Warning messages:
1: "$$ondelim" does not follow the given naming conventions (description = "")! 
2: "$$include" does not follow the given naming conventions (description = "./some/file/to/read.csv")!
```

Better to filter $$-expressions, too.