### PR TITLE
accept 1-3 just like 1:3 in chooseFromList

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6164350'
+ValidationKey: '6186101'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.31.0
-date-released: '2024-06-11'
+version: 0.31.1
+date-released: '2024-06-17'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.31.0
-Date: 2024-06-11
+Version: 0.31.1
+Date: 2024-06-17
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/chooseFromList.R
+++ b/R/chooseFromList.R
@@ -79,8 +79,8 @@ chooseFromList <- function(theList, type = "items", userinfo = NULL, addAllPatte
     userinput <- getLine()
   }
   # interpret userinput and perform basic checks
-  identifier <- try(eval(parse(text = paste("c(", userinput, ")"))), silent = TRUE)
-  if (! all(grepl(if (addAllPattern) "^[afp0-9,: ]*$" else "^[0-9,: ]*$", userinput)) || inherits(identifier, "try-error")) {
+  identifier <- try(eval(parse(text = paste("c(", gsub("-", ":", userinput), ")"))), silent = TRUE)
+  if (! all(grepl(if (addAllPattern) "^[afp0-9,: -]*$" else "^[0-9,: -]*$", userinput)) || inherits(identifier, "try-error")) {
     err <- paste0("Try again, you have to choose some numbers. ", attr(identifier, "condition"), "\n")
     return(chooseFromList(originalList, type, userinfo, addAllPattern, returnBoolean, multiple, errormessage = err))
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.31.0**
+R package **gms**, version **0.31.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.31.0, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.31.1, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.31.0},
+  note = {R package version 0.31.1},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }

--- a/tests/testthat/test-chooseFromList.R
+++ b/tests/testthat/test-chooseFromList.R
@@ -30,6 +30,10 @@ with_mocked_bindings({ # fail if getLine() is called
                      theList[1])
     expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "  1 :  1  "),
                      theList[1])
+    expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "  1 -  1  "),
+                     theList[1])
+    expect_identical(chooseFromList(theList, addAllPattern = FALSE, userinput = "  1 -  2  "),
+                     theList[1:2])
     expect_identical(unname(chooseFromList(theList, userinput = "1", returnBoolean = TRUE)),
                      rep(TRUE, length(theList)))
     expect_identical(chooseFromList(theList, userinput = toString(length(theList) + 2)),
@@ -59,8 +63,8 @@ with_mocked_bindings({ # fail if getLine() is called
     expect_error(chooseFromList(theList, userinput = "1,:3,"))
     expect_error(chooseFromList(theList, userinput = "0"))
     expect_error(chooseFromList(theList, userinput = "-1"))
-    expect_error(chooseFromList(theList, userinput = "1-2"))
     expect_error(chooseFromList(theList, multiple = FALSE, userinput = "1:2"))
+    expect_error(chooseFromList(theList, multiple = FALSE, userinput = "1-2"))
   })
 
   test_that("chooseFromList works with multiple groups", {


### PR DESCRIPTION
- allow to select multiple items like `1:3,6` also as `1-3,6`
- I find that a bit more convenient, in particular on the num block
- method: accept `-` as input, and then simply replace it by `:` before `eval` is executed