### PR TITLE
drop empty module subfolders in getModules

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6209112'
+ValidationKey: '6233082'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.31.2
-date-released: '2024-06-27'
+version: 0.31.3
+date-released: '2024-07-10'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.31.2
-Date: 2024-06-27
+Version: 0.31.3
+Date: 2024-07-10
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/getModules.R
+++ b/R/getModules.R
@@ -13,6 +13,11 @@
 getModules <- function(modulepath) {
   if(!dir.exists(modulepath)) stop("Module path ",modulepath," does not exist!")
   folder <- base::list.dirs(path=modulepath,full.names = FALSE,recursive = FALSE)
+  emptyfolder <- folder[unlist(lapply(lapply(file.path(modulepath, folder), list.files, ".*\\.gms$"), length)) == 0]
+  if (length(emptyfolder) > 0) {
+    warning("The following module folders contain no '*.gms' file and are ignored: ", paste(emptyfolder, collapse = ", "))
+  }
+  folder <- setdiff(folder, emptyfolder)
   name   <- gsub("[0-9]+\\_","",folder)
   number <- gsub("([0-9]+)\\_.*","\\1",folder) 
   out    <- cbind(name,number,folder)

--- a/R/replace_in_file.R
+++ b/R/replace_in_file.R
@@ -51,8 +51,8 @@ replace_in_file <- function(file, content, subject='CODE',add=FALSE,addfile=FALS
   
   start_row <- grep(start,f)
   end_row <- grep(end,f)
-  if(length(start_row)!=length(end_row)) stop("start pattern was found ",length(start_row), " times, but end pattern was found ",length(end_row), "times!")
-  if(length(start_row)>1) stop(paste("pattern was found",length(start_row),"times!"))
+  if(length(start_row)!=length(end_row)) stop("start pattern was found ",length(start_row), " times, but end pattern was found ",length(end_row), " times in ", file, "!")
+  if(length(start_row)>1) stop("pattern was found ",length(start_row)," times in ", file, "!")
   if(length(end_row)==0) {
     if(add=="top"){
       f <- c("",start_raw,end_raw,"",f)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.31.2**
+R package **gms**, version **0.31.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.31.2, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.31.3, <URL: https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.31.2},
+  note = {R package version 0.31.3},
   doi = {10.5281/zenodo.4390032},
   url = {https://github.com/pik-piam/gms},
 }


### PR DESCRIPTION
- if a module was renamed (as was the case with `29_ageclass` -> `28_ageclass` in MAgPIE) or deleted (as was the case with `30_crop` in MAgPIE), but git does not delete the folder because of some input files lying around, the scripts fails
- See for example REMIND's automated model tests: `/p/projects/remind/modeltests/remind/tests/test-full-2024-07-09.log`:
```
Error: Chosen realization "feb21" does not exist for module "ageclass"
Execution halted
```

- With this PR: in `getModules`, drop folders that do not contain a single `*.gms` file (usually: `module.gms`), and raise a warning instead
- For REMIND, after creating an empty `18_test` folder and executing `Rscript start.R -t`, before and after this PR:
```
Error: Chosen realization "NULL" does not exist for module "test"
```
```
Warning message:
In getModules(modulepath = modulepath) :
  The following module folders contain no '*.gms' file and are ignored: 18_test
```
- also fixes #100 