### PR TITLE
Add option to pass a scenario config as data frame to setScenario()

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6233082'
+ValidationKey: '6377280'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.31.3
-date-released: '2024-07-10'
+version: 0.32.0
+date-released: '2024-07-25'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.31.3
-Date: 2024-07-10
+Version: 0.32.0
+Date: 2024-07-25
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),
@@ -38,5 +38,5 @@ BugReports: https://github.com/pik-piam/gms/issues
 License: BSD_2_clause + file LICENSE
 LazyData: no
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Config/Keywords: tool

--- a/R/setScenario.R
+++ b/R/setScenario.R
@@ -1,14 +1,15 @@
 #' setScenario
-#' 
+#'
 #' setScenario is adapting a given config to a predefined scenario, meaning
 #' that all settings which are fixed for the given scenario are written to the
 #' config. Settings not defined by the scenario remain unchanged.
-#' 
-#' 
+#'
+#'
 #' @param cfg Input config which should be adapted to the given scenario
 #' @param scenario name of scenario (e.g. "SSP2"). Can also be a vector of
 #' scenarios. In this case scenario settings are applied in the given order
-#' @param scenario_config The path where the scenario config table is stored.
+#' @param scenario_config A data frame containing the scenario config table
+#' or the path where the scenario config table is stored.
 #' @return The updated config as a config list ready for further usage.
 #' @note The scenario config table is a table which contains as columns the
 #' different scenarios and as rows the different settings. Empty entries for a
@@ -19,46 +20,41 @@
 #' @importFrom utils read.csv
 #' @seealso \code{\link{check_config}},\code{\link{getModules}}
 setScenario <- function(cfg,scenario,scenario_config="config/scenario_config.csv"){
-  
-  # setwd("~/0_SVN/MAgPIE_SSP")
-  # source("config/default_test.cfg")
-  # source("config/default.cfg")
-  # scenario <- "n600"
-  # x <- scenario
-  # scenario_config <-"config/scenario_config_test.csv"
-  # scenario_config <-"config/scenario_config.csv"
-  
-    if (!is.list(cfg)) {
-      if (is.character(cfg)) {
-        if (file.exists(path("config", cfg))) 
-          cfg <- path("config", cfg)
-        source(cfg, local = TRUE)
-        if (!is.list(cfg)) 
-          stop("Wrong input file format: config file does not contain a cfg list!")
-      }
-      else {
-        stop("Wrong input format: cfg is neither a list nor a character!")
-      }
+
+  if (!is.list(cfg)) {
+    if (is.character(cfg)) {
+      if (file.exists(path("config", cfg)))
+        cfg <- path("config", cfg)
+      source(cfg, local = TRUE)
+      if (!is.list(cfg))
+        stop("Wrong input file format: config file does not contain a cfg list!")
     }
+    else {
+      stop("Wrong input format: cfg is neither a list nor a character!")
+    }
+  }
+
+  if (!is.data.frame(scenario_config)) {
     tmp <- try(read.csv(scenario_config, as.is = TRUE, check.names = FALSE, colClasses = "character"), silent = TRUE)
-    #check whether reading the table was succesfull, if not try to read it differently
+    #check whether reading the table was successful, if not try to read it differently
     if(inherits(tmp, "try-error") || all(dimnames(tmp)[[1]]==as.character(1:dim(tmp)[1]))) {
       tmp <- read.csv(scenario_config, as.is=TRUE, sep=";", check.names=FALSE, colClasses = "character")
       dimnames(tmp)[[1]] <- tmp[,1]
       tmp <- tmp[,-1]
     }
     scenario_config <- tmp
-    
-    
+  }
+
+
   for (x in scenario) {
     if(!(x %in% colnames(scenario_config))) stop("No settings for scenario ", x, " found in scenario config!")
     message("\nApply ", x, " settings on config:")
-    
+
     # if there are no switches containing "$" all switches are interpreted as gams switches
     if (!any(grepl("\\$",rownames(scenario_config)))) {
       rownames(scenario_config) <- paste0("gms$",rownames(scenario_config))
     }
-    
+
     # loop over switches to chanhe their values
     for(i in rownames(scenario_config)){
       from <- eval(parse(text=paste0("cfg$",i))) # this way, because i can contain a list. In this case access with [[i]] would not work
@@ -70,10 +66,10 @@ setScenario <- function(cfg,scenario,scenario_config="config/scenario_config.csv
         if(grepl(",",to,fixed=TRUE)) to <- strsplit(to,",")[[1]]
         # finally set the switch
         eval(parse(text=paste0("cfg$",i, "<- to")))
-      }   
+      }
     }
     message("Config successfully updated!\n")
   }
-    
-  return(cfg)  
+
+  return(cfg)
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.31.3**
+R package **gms**, version **0.32.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi: 10.5281/zenodo.4390032 (URL: https://doi.org/10.5281/zenodo.4390032), R package version 0.31.3, <URL: https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.32.0, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,8 +52,8 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.31.3},
-  doi = {10.5281/zenodo.4390032},
+  note = {R package version 0.32.0},
   url = {https://github.com/pik-piam/gms},
+  doi = {10.5281/zenodo.4390032},
 }
 ```

--- a/man/setScenario.Rd
+++ b/man/setScenario.Rd
@@ -12,7 +12,8 @@ setScenario(cfg, scenario, scenario_config = "config/scenario_config.csv")
 \item{scenario}{name of scenario (e.g. "SSP2"). Can also be a vector of
 scenarios. In this case scenario settings are applied in the given order}
 
-\item{scenario_config}{The path where the scenario config table is stored.}
+\item{scenario_config}{A data frame containing the scenario config table
+or the path where the scenario config table is stored.}
 }
 \value{
 The updated config as a config list ready for further usage.


### PR DESCRIPTION
So far it was only possible to pass a path to a `scenario_config.csv` to the function. Now you can also pass a data frame that contains the scenario config.