### PR TITLE
allow to specify main file name in readDefaultConfig

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6377280'
+ValidationKey: '6400740'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.32.0
-date-released: '2024-07-25'
+version: 0.32.1
+date-released: '2024-08-05'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.32.0
-Date: 2024-07-25
+Version: 0.32.1
+Date: 2024-08-05
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/readDefaultConfig.R
+++ b/R/readDefaultConfig.R
@@ -1,10 +1,12 @@
 #' readDefaultConfig
 #'
-#' Reads the default configuration of the model. Uses default.cfg or main.cfg as the source as appropriate.
+#' Reads the default configuration of the model. Uses default.cfg and the model's main gms
+#' as the source as appropriate.
 #' To read a configuration from YAML format, use \code{\link{loadConfig}} instead.
 #'
 #'
 #' @param path path of the main folder of the model
+#' @param mainfile filename of main model file, defaults to 'main.gms'
 #' @return A vector of parameter values and their names.
 #' @author Mika Pflüger
 #' @seealso \code{\link{loadConfig}}
@@ -12,14 +14,14 @@
 #' @importFrom utils modifyList
 #' @export
 
-readDefaultConfig <- function(path) {
+readDefaultConfig <- function(path = ".", mainfile = "main.gms") {
   # read in settings from main.gms first
   cfg <- list()
-  fileMain <- file.path(path, "main.gms")
+  fileMain <- file.path(path, mainfile)
   if (file.exists(fileMain)) {
     cfg$gms <- as.list(readSettings(fileMain))
   } else {
-    stop("readDefaultConfig cannot find main.gms in ", normalizePath(path))
+    stop("readDefaultConfig cannot find ", mainfile, " in ", normalizePath(path))
   }
   # overwrite with settings from default.cfg
   env <- new.env()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.32.0**
+R package **gms**, version **0.32.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.32.0, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.32.1, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.32.0},
+  note = {R package version 0.32.1},
   url = {https://github.com/pik-piam/gms},
   doi = {10.5281/zenodo.4390032},
 }

--- a/man/readDefaultConfig.Rd
+++ b/man/readDefaultConfig.Rd
@@ -4,16 +4,19 @@
 \alias{readDefaultConfig}
 \title{readDefaultConfig}
 \usage{
-readDefaultConfig(path)
+readDefaultConfig(path = ".", mainfile = "main.gms")
 }
 \arguments{
 \item{path}{path of the main folder of the model}
+
+\item{mainfile}{filename of main model file, defaults to 'main.gms'}
 }
 \value{
 A vector of parameter values and their names.
 }
 \description{
-Reads the default configuration of the model. Uses default.cfg or main.cfg as the source as appropriate.
+Reads the default configuration of the model. Uses default.cfg and the model's main gms
+as the source as appropriate.
 To read a configuration from YAML format, use \code{\link{loadConfig}} instead.
 }
 \seealso{


### PR DESCRIPTION
- Allow to use a different file than `main.gms` as model main file.
- I need that for implementing a test in REMIND.