### PR TITLE
Add the option to individually define for each input file whether to warn or stop in case the file is not found.

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6400740'
+ValidationKey: '6591750'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
+    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.32.1
-date-released: '2024-08-05'
+version: 0.33.0
+date-released: '2024-09-09'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.32.1
-Date: 2024-08-05
+Version: 0.33.0
+Date: 2024-09-09
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/download_unpack.R
+++ b/R/download_unpack.R
@@ -43,8 +43,10 @@ download_unpack <- function(input, targetdir = "input", repositories = NULL,
   }
 
   # treat all files the same way if stopOnMissing is not defined individually for each element in `files`
-  if (length(stopOnMissing) < length(files)) {
+  if (length(stopOnMissing) == 1) {
     stopOnMissing <- rep(stopOnMissing, length(files))
+  } else if (length(stopOnMissing) != length(files)) {
+    stop("stopOnMissing must have exactly one element, or as many elements as files")
   }
 
   ifiles <- files

--- a/R/download_unpack.R
+++ b/R/download_unpack.R
@@ -17,7 +17,8 @@
 #' @param debug switch for debug mode with additional diagnostic information
 #' @param unpack if switched off the source files are purley downloaded
 #' @param stopOnMissing Boolean indicating whether to stop if any file in
-#'   `files` could not be downloaded.  Off (`FALSE`) by default.
+#'   `files` could not be downloaded. Off (`FALSE`) by default. Can either be defined as a single boolean, which then
+#'   applies equally to all elements of `files`, or can be defined individually for each element in `files`.
 
 #' @return Information about the download process in form of a data.frame with data sets as row names and repositories
 #' (where it was downloaded from) and corresponding md5sum as columns
@@ -39,6 +40,11 @@ download_unpack <- function(input, targetdir = "input", repositories = NULL,
       repositories <- vector("list", length(input))
       names(repositories) <- dirname(input)
     }
+  }
+
+  # treat all files the same way if stopOnMissing is not defined individually for each element in `files`
+  if (length(stopOnMissing) < length(files)) {
+    stopOnMissing <- rep(stopOnMissing, length(files))
   }
 
   ifiles <- files
@@ -94,19 +100,25 @@ download_unpack <- function(input, targetdir = "input", repositories = NULL,
     if (length(files) == 0) break
   }
 
+  # if there are files left that could not be downloaded
   if (length(files) > 0) {
-    tmp <- paste0("Following files not found:\n  ", paste(files, collapse = "\n  "))
-    if (stopOnMissing) {
-      stop(tmp)
-    } else {
+    # first the warning
+    optionalFiles <- ifiles %in% files & !stopOnMissing
+    if (any(optionalFiles)) {
+      tmp <- paste0("Following optional files not found:\n  ", paste(ifiles[optionalFiles], collapse = "\n  "))
       warning(tmp)
       message(tmp)
     }
+    # then the error
+    mandatoryFiles <- ifiles %in% files & stopOnMissing
+    if (any(mandatoryFiles)) stop(paste0("Following files not found:\n  ", paste(ifiles[mandatoryFiles], collapse = "\n  ")))
   }
+
   if (is.null(found)) {
     message()
     stop("No file could be found!")
   }
+
   # sort files in intial order and unpack
   found <- found[intersect(ifiles, rownames(found)), ]
   if (unpack) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.32.1**
+R package **gms**, version **0.33.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.32.1, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.33.0, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.32.1},
+  note = {R package version 0.33.0},
   url = {https://github.com/pik-piam/gms},
   doi = {10.5281/zenodo.4390032},
 }

--- a/man/download_unpack.Rd
+++ b/man/download_unpack.Rd
@@ -32,7 +32,8 @@ list("ftp://my_pw_protected_server.de/data"=list(user="me",password=12345), "htt
 \item{unpack}{if switched off the source files are purley downloaded}
 
 \item{stopOnMissing}{Boolean indicating whether to stop if any file in
-\code{files} could not be downloaded.  Off (\code{FALSE}) by default.}
+\code{files} could not be downloaded. Off (\code{FALSE}) by default. Can either be defined as a single boolean, which then
+applies equally to all elements of \code{files}, or can be defined individually for each element in \code{files}.}
 }
 \value{
 Information about the download process in form of a data.frame with data sets as row names and repositories


### PR DESCRIPTION
So far `stopOnMissing` is a single boolean. This PR introduces the option to provide a vector for `stopOnMissing` that individually defines for each input file whether to warn or stop if the respective file is not found. If `stopOnMissing` has a single element, it applies equally to all input files. This ensures backwards compatibility.