### PR TITLE
Print a message only instead of throwing a warning

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6612056'
+ValidationKey: '6641660'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.33.1
-date-released: '2024-09-10'
+version: 0.33.2
+date-released: '2024-10-09'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.33.1
-Date: 2024-09-10
+Version: 0.33.2
+Date: 2024-10-09
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/download_unpack.R
+++ b/R/download_unpack.R
@@ -104,14 +104,13 @@ download_unpack <- function(input, targetdir = "input", repositories = NULL,
 
   # if there are files left that could not be downloaded
   if (length(files) > 0) {
-    # first the warning
+    # first the message (for optional files)
     optionalFiles <- ifiles %in% files & !stopOnMissing
     if (any(optionalFiles)) {
       tmp <- paste0("Following optional files not found:\n  ", paste(ifiles[optionalFiles], collapse = "\n  "))
-      warning(tmp)
       message(tmp)
     }
-    # then the error
+    # then the error (for mandatory files)
     mandatoryFiles <- ifiles %in% files & stopOnMissing
     if (any(mandatoryFiles)) stop(paste0("Following files not found:\n  ", paste(ifiles[mandatoryFiles], collapse = "\n  ")))
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.33.1**
+R package **gms**, version **0.33.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.33.1, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.33.2, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.33.1},
+  note = {R package version 0.33.2},
   url = {https://github.com/pik-piam/gms},
   doi = {10.5281/zenodo.4390032},
 }


### PR DESCRIPTION
Print a message only instead of throwing a warning if an *optional* input file is missing.