### PR TITLE
 remove blanks in readDeclarations 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6641660'
+ValidationKey: '6662331'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.33.2
-date-released: '2024-10-09'
+version: 0.33.3
+date-released: '2024-10-11'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.33.2
-Date: 2024-10-09
+Version: 0.33.3
+Date: 2024-10-11
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/readDeclarations.R
+++ b/R/readDeclarations.R
@@ -44,6 +44,8 @@ readDeclarations <- function(file,
       names(quotedDescription) <- paste0("[#DESC#", seq_along(tmp), "#]")
       # insert placeholders
       tmp <- str_replace(tmp, "\"[^\"]*\"", names(quotedDescription))
+      # remove blanks
+      tmp <- trimws(tmp)
       # remove ;
       tmp <- sub(";", "", tmp)
       # remove $-expressions
@@ -51,7 +53,7 @@ readDeclarations <- function(file,
       # remove type name
       tmp <- sub(paste0("^[ \\t]*", t, "[^ \\t]*"), "", tmp, ignore.case = TRUE)
       # remove "/ xyz /" entries
-      tmp <- sub("/.*/", "", tmp)
+      tmp <- sub("[[:space:]]*/.*/", "", tmp)
       .rmFilling <- function(x) {
         n <- grep("/", x)
         if (length(n) < 2)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.33.2**
+R package **gms**, version **0.33.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.33.2, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2024). _gms: 'GAMS' Modularization Support Package_. doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, R package version 0.33.3, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,7 +52,7 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   year = {2024},
-  note = {R package version 0.33.2},
+  note = {R package version 0.33.3},
   url = {https://github.com/pik-piam/gms},
   doi = {10.5281/zenodo.4390032},
 }

--- a/tests/testthat/test-readDeclarations.R
+++ b/tests/testthat/test-readDeclarations.R
@@ -17,21 +17,34 @@ example <- c(
 "",
 "pm_EN_demand_from_initialcap2(all_regi,all_enty) \"PE demand. Unit: EJ, except for Uranium, where it is MT U3O8\"",
 "pm_budgetCO2eq(all_regi)                                        \"budget for regional energy-emissions in period 1\"",
+"  pm_empty_desc(all_regi)  \"\""  ,
+";",
+"sets",
+"  empty_set  \"\"  / /",
 ";",
 "",
 "*** EOF ./core/declarations.gms")
 
 expectedResult <- structure(c(
+  # names
   "pm_taxCO2eq", "pm_gdp_gdx", "p_inv_gdx", "pm_eta_conv",
-  "pm_EN_demand_from_initialcap2", "pm_budgetCO2eq", "ttot,all_regi",
-  "tall,all_regi", "tall,all_regi", "tall,all_regi,all_te", "all_regi,all_enty",
-  "all_regi", "CO2 tax path in T$/GtC = kgC. To get tCO2, multiply with 272",
-  "GDP path from gdx, updated /iteratively", "macro-investments  path from gdx, updated iteratively",
+  "pm_EN_demand_from_initialcap2", "pm_budgetCO2eq", "pm_empty_desc", "empty_set",
+  # sets
+  "ttot,all_regi", "tall,all_regi", "tall,all_regi", "tall,all_regi,all_te",
+  "all_regi,all_enty", "all_regi", "all_regi", "",
+  # descriptions
+  "CO2 tax path in T$/GtC = kgC. To get tCO2, multiply with 272",
+  "GDP path from gdx, updated /iteratively",
+  "macro-investments  path from gdx, updated iteratively",
   "Time-dependent, until 2050 to. Unit: efficiency (0..1, except for tnrs)",
   "PE demand. Unit: EJ, except for Uranium, where it is MT U3O8",
-  "budget for regional energy-emissions in period 1", "parameter",
-  "parameter", "parameter", "parameter", "parameter", "parameter"
-), .Dim = c(6L, 4L), .Dimnames = list(NULL, c("names", "sets",
+  "budget for regional energy-emissions in period 1",
+  "",
+  "",
+  # types
+  "parameter", "parameter", "parameter", "parameter",
+  "parameter", "parameter", "parameter", "set"
+), .Dim = c(8L, 4L), .Dimnames = list(NULL, c("names", "sets",
                                               "description", "type")))
 
 test_that("all parameters in example are properly detected", {


### PR DESCRIPTION
Without that,
```
sets
  empty_set  ""  / /
;
```
would result in the description being read as `"   "`, which is why some empty descriptions in REMIND [went unnoticed](https://github.com/remindmodel/remind/pull/1859/files#diff-aa31f6bfb877de1770c8981ff6318d45727e5d4dc7351f17cb60bc714ed6798c).

Adjust test to show it now works as intended, which will then correctly raise errors in codeCheck