### PR TITLE
Improves update_module_embedding to handle missing end patterns 

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6787770'
+ValidationKey: '6815424'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,15 +35,6 @@ jobs:
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install python dependencies if applicable
-        run: |
-          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
-          [ -f requirements.txt ] && pip install -r requirements.txt || true
-
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.33.5
-date-released: '2025-06-23'
+version: 0.33.6
+date-released: '2025-07-15'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.33.5
-Date: 2025-06-23
+Version: 0.33.6
+Date: 2025-07-15
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -121,7 +121,7 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
                     path(modelpath, modulepath, module, t, phase, ftype = "gms"), "\"", sep = ""))
         } else if (verbose) message(module, " ", t, ": ", phase, "is not used")
       }
-      replace_in_file(realizationGMSpaths[ti], code, subject = "PHASES")
+      replace_in_file(realizationGMSpaths[ti], code, add="bottom", subject = "PHASES")
     }
   }
 

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -108,7 +108,7 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
     types <- types[! emptyrealization]
     realizationGMSpaths <- realizationGMSpaths[! emptyrealization]
     code <- paste0("$Ifi \"%", substring(module, 4), "%\" == \"", types, "\" $include \"", realizationGMSpaths, "\"")
-    replace_in_file(moduleGMSpaths[m], code, subject = "MODULETYPES")
+    replace_in_file(moduleGMSpaths[m], code, add="bottom", subject = "MODULETYPES")
 
     #set links to different module phases
     for (ti in seq_along(types)) {

--- a/R/update_modules_embedding.R
+++ b/R/update_modules_embedding.R
@@ -108,7 +108,7 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
     types <- types[! emptyrealization]
     realizationGMSpaths <- realizationGMSpaths[! emptyrealization]
     code <- paste0("$Ifi \"%", substring(module, 4), "%\" == \"", types, "\" $include \"", realizationGMSpaths, "\"")
-    replace_in_file(moduleGMSpaths[m], code, add="bottom", subject = "MODULETYPES")
+    replace_in_file(moduleGMSpaths[m], code, add = "bottom", subject = "MODULETYPES")
 
     #set links to different module phases
     for (ti in seq_along(types)) {
@@ -121,7 +121,7 @@ update_modules_embedding <- function(modelpath = ".", modulepath = "modules/",
                     path(modelpath, modulepath, module, t, phase, ftype = "gms"), "\"", sep = ""))
         } else if (verbose) message(module, " ", t, ": ", phase, "is not used")
       }
-      replace_in_file(realizationGMSpaths[ti], code, add="bottom", subject = "PHASES")
+      replace_in_file(realizationGMSpaths[ti], code, add = "bottom", subject = "PHASES")
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.33.5**
+R package **gms**, version **0.33.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2025). "gms: 'GAMS' Modularization Support Package." doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, Version: 0.33.5, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2025). "gms: 'GAMS' Modularization Support Package." doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, Version: 0.33.6, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,9 +52,9 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   doi = {10.5281/zenodo.4390032},
-  date = {2025-06-23},
+  date = {2025-07-15},
   year = {2025},
   url = {https://github.com/pik-piam/gms},
-  note = {Version: 0.33.5},
+  note = {Version: 0.33.6},
 }
 ```

--- a/tests/testthat/test-update_modules_embedding.R
+++ b/tests/testthat/test-update_modules_embedding.R
@@ -25,30 +25,41 @@
 
 test_that("update_modules_embedding full test", {
   withr::local_dir(withr::local_tempdir())
-  modulesPath <- file.path("modules") 
-  module21Path <- file.path(modulesPath, "21_testmodule")
-  .setup_update_modules_embedding(modulesPath, module21Path)
+  module21Path <- file.path("modules", "21_testmodule")
+  .setup_update_modules_embedding("modules", module21Path)
 
   dir.create(file.path(module21Path, "empty"))
   
   expect_warning(update_modules_embedding(modulepath = "modules/",
                                           includefile = "modules/include.gms", verbose = FALSE), "empty")
   expect_true(any(grepl("testmodule", readLines(file.path("core", "sets.gms"), warn = FALSE))))
-  expect_true(any(grepl("21_testmodule", readLines(file.path(modulesPath, "include.gms"), warn = FALSE))))
+  expect_true(any(grepl("21_testmodule", readLines(file.path("modules", "include.gms"), warn = FALSE))))
   expect_true(any(grepl("works", readLines(file.path(module21Path, "module.gms"), warn = FALSE))))
   expect_false(any(grepl("empty", readLines(file.path(module21Path, "module.gms"), warn = FALSE))))
   expect_true(any(grepl("sets", readLines(file.path(module21Path, "works", "realization.gms"), warn = FALSE))))
+  
 })
 
-test_that("update_modules_embedding missing patterns test", {
+test_that("update_modules_embedding missing end pattern in realization.gms test", {
   withr::local_dir(withr::local_tempdir())
-  modulesPath <- file.path("modules") 
-  module21Path <- file.path(modulesPath, "21_testmodule")
-  .setup_update_modules_embedding(modulesPath, module21Path)
+  module21Path <- file.path("modules", "21_testmodule")
+  .setup_update_modules_embedding("modules", module21Path)
 
-  writeLines(c(""),
-             file.path(module21Path, "works", "realization.gms"))
+  writeChar("", file.path(module21Path, "works", "realization.gms"))
   update_modules_embedding(modulepath = "modules/",
-                           includefile = "modules/include.gms", verbose = FALSE) 
+                          includefile = "modules/include.gms", verbose = FALSE) 
   expect_true(any(grepl("sets", readLines(file.path(module21Path, "works", "realization.gms"), warn = FALSE))))
+})
+
+test_that("update_modules_embedding missing end pattern in module.gms test", {
+  withr::local_dir(withr::local_tempdir())
+  module21Path <- file.path("modules", "21_testmodule")
+  .setup_update_modules_embedding("modules", module21Path)
+
+  dir.create(file.path(module21Path, "empty"))
+  writeChar("", file.path(module21Path, "module.gms"))
+
+  expect_warning(update_modules_embedding(modulepath = "modules/",
+                                          includefile = "modules/include.gms", verbose = FALSE), "empty")
+  expect_true(any(grepl("works", readLines(file.path(module21Path, "module.gms"), warn = FALSE))))
 })

--- a/tests/testthat/test-update_modules_embedding.R
+++ b/tests/testthat/test-update_modules_embedding.R
@@ -1,36 +1,54 @@
-test_that("update_modules_embedding test", {
-  modelpath <- tempdir()
+.setup_update_modules_embedding <- function(modulesPath, module21Path) {
   writeLines(c('$include    "./core/sets.gms";',
                '$batinclude "./modules/include.gms"    sets'),
-             file.path(modelpath, "main.gms"))
-  dir.create(file.path(modelpath, "core"))
+             file.path("main.gms"))
+  dir.create(file.path("core"))
   writeLines(c("***######################## R SECTION START (MODULES) ###############################",
                "module2realisation",
                "***######################### R SECTION END (MODULES) ################################"),
-             file.path(modelpath, "core", "sets.gms"))
-  modulepath <- file.path(modelpath, "modules") 
-  dir.create(modulepath)
+             file.path("core", "sets.gms"))
+  dir.create(modulesPath)
   writeLines(c("*######################## R SECTION START (MODULES) ############################",
                "*######################## R SECTION END (MODULES) ##############################"),
-             file.path(modulepath, "include.gms"))
-  module21path <- file.path(modulepath, "21_testmodule")
-  dir.create(module21path)
+             file.path(modulesPath, "include.gms"))
+  dir.create(module21Path)
   writeLines(c("*###################### R SECTION START (MODULETYPES) ##########################",
                "*###################### R SECTION END (MODULETYPES) ############################"),
-             file.path(module21path, "module.gms"))
-  dir.create(file.path(module21path, "empty"))
-  dir.create(file.path(module21path, "works"))
+             file.path(module21Path, "module.gms"))
+  dir.create(file.path(module21Path, "works"))
   writeLines(c("*####################### R SECTION START (PHASES) ##############################",
                "*######################## R SECTION END (PHASES) ###############################"),
-             file.path(module21path, "works", "realization.gms"))
+             file.path(module21Path, "works", "realization.gms"))
   writeLines("some GAMS code",
-             file.path(module21path, "works", "sets.gms"))
-  expect_warning(update_modules_embedding(modelpath = modelpath, modulepath = "modules/",
+             file.path(module21Path, "works", "sets.gms"))
+}
+
+test_that("update_modules_embedding full test", {
+  withr::local_dir(withr::local_tempdir())
+  modulesPath <- file.path("modules") 
+  module21Path <- file.path(modulesPath, "21_testmodule")
+  .setup_update_modules_embedding(modulesPath, module21Path)
+
+  dir.create(file.path(module21Path, "empty"))
+  
+  expect_warning(update_modules_embedding(modulepath = "modules/",
                                           includefile = "modules/include.gms", verbose = FALSE), "empty")
-  expect_true(any(grepl("testmodule", readLines(file.path(modelpath, "core", "sets.gms"), warn = FALSE))))
-  expect_true(any(grepl("21_testmodule", readLines(file.path(modulepath, "include.gms"), warn = FALSE))))
-  expect_true(any(grepl("works", readLines(file.path(module21path, "module.gms"), warn = FALSE))))
-  expect_false(any(grepl("empty", readLines(file.path(module21path, "module.gms"), warn = FALSE))))
-  expect_true(any(grepl("sets", readLines(file.path(module21path, "works", "realization.gms"), warn = FALSE))))
+  expect_true(any(grepl("testmodule", readLines(file.path("core", "sets.gms"), warn = FALSE))))
+  expect_true(any(grepl("21_testmodule", readLines(file.path(modulesPath, "include.gms"), warn = FALSE))))
+  expect_true(any(grepl("works", readLines(file.path(module21Path, "module.gms"), warn = FALSE))))
+  expect_false(any(grepl("empty", readLines(file.path(module21Path, "module.gms"), warn = FALSE))))
+  expect_true(any(grepl("sets", readLines(file.path(module21Path, "works", "realization.gms"), warn = FALSE))))
 })
 
+test_that("update_modules_embedding missing patterns test", {
+  withr::local_dir(withr::local_tempdir())
+  modulesPath <- file.path("modules") 
+  module21Path <- file.path(modulesPath, "21_testmodule")
+  .setup_update_modules_embedding(modulesPath, module21Path)
+
+  writeLines(c(""),
+             file.path(module21Path, "works", "realization.gms"))
+  update_modules_embedding(modulepath = "modules/",
+                           includefile = "modules/include.gms", verbose = FALSE) 
+  expect_true(any(grepl("sets", readLines(file.path(module21Path, "works", "realization.gms"), warn = FALSE))))
+})


### PR DESCRIPTION
This changes `update_module_embedding` to add end patterns (`#+ R SECTION START ...`) for `realization.gms` and `module.gms` in case they are not present. 

While this could be done for other files (`include.gms` and `sets.gms`), I decided against it, as a missing end pattern in these files might indicate a more general problem.

With this change the code snippets in the _Creating a new realization_ tutorial work, otherwise they will fail in the step _Update the code_.

(Depends on #110 )