### PR TITLE
Faster code check

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '7011480'
+ValidationKey: '7219100'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'gms: ''GAMS'' Modularization Support Package'
-version: 0.34.0
-date-released: '2026-06-18'
+version: 0.35.0
+date-released: '2026-06-22'
 abstract: A collection of tools to create, use and maintain modularized model code
   written in the modeling language 'GAMS' (<https://www.gams.com/>). Out-of-the-box
   'GAMS' does not come with support for modularized model code. This package provides

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gms
 Type: Package
 Title: 'GAMS' Modularization Support Package
-Version: 0.34.0
-Date: 2026-06-18
+Version: 0.35.0
+Date: 2026-06-22
 Authors@R: c(person("Jan Philipp", "Dietrich", email = "dietrich@pik-potsdam.de", 
              comment = c(affiliation = "Potsdam Institute for Climate Impact Research", ORCID = "0000-0002-4309-6431"), role = c("aut","cre")),
              person("David", "Klein", comment = c(affiliation = "Potsdam Institute for Climate Impact Research"), role = "aut"),

--- a/R/checkAppearance.R
+++ b/R/checkAppearance.R
@@ -55,7 +55,6 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   code <- x$code
   code <- gsub("\"[^\"]*\"", "", code)
   code <- gsub("'[^']*'", "", code)
-  code <- gsub("display.*", "", code)
 
   message("  Start variable matching...            (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
@@ -86,17 +85,18 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   message("  Start var capitalization check...     (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
 
+  tokenVecForCap        <- unlist(strsplit(code, "[^[:alnum:]_]+", perl = TRUE),
+                                  use.names = FALSE)
+  lowerTokenVecForCap   <- tolower(tokenVecForCap)
+
   # Find symbols that appear with more than one capitalisation variant in the code.
-  # Uses the prebuilt token vector (O(tokens) build + O(1) per symbol lookup).
-  # tapply groups tokenVec by lowerTokenVec (its grouping key, same length) and counts the
-  # distinct casings within each group; any group with more than one casing is a duplicate.
-  casingCounts <- tapply(tokenVec, lowerTokenVec, function(v) length(unique(v)))
+  # tapply groups actual tokens by their lowercase form; count > 1 means mixed casing.
+  casingCounts <- tapply(tokenVecForCap, lowerTokenVecForCap, function(v) length(unique(v)))
   multiCaseSet <- names(casingCounts)[casingCounts > 1L]
   duplicates   <- tolower(objectNames) %in% multiCaseSet
   names(duplicates) <- objectNames
 
   if (length(objectNames[setdiff(objectNames[duplicates], capitalExclusionList)] > 0)) {
-
     duplicateNames <- unname(setdiff(objectNames[duplicates], capitalExclusionList))
 
     msg <- paste0(
@@ -111,7 +111,7 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
 
       tokens <- strsplit(chunks, "[^[:alnum:]_]+", perl = TRUE)
       correctTokenCounts <- vapply(tokens, function(line) sum(dup == line), integer(1))
-      allTokenCounts <- vapply(tokens, function(line) sum(dup == tolower(line)), integer(1))
+      allTokenCounts <- vapply(tokens, function(line) sum(tolower(dup) == tolower(line)), integer(1))
       suspectLines <- chunks[correctTokenCounts != allTokenCounts]
 
       msg <- paste0(msg, paste0(paste(" - ", suspectLines), collapse = "\n"))

--- a/R/checkAppearance.R
+++ b/R/checkAppearance.R
@@ -73,11 +73,11 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   symbolTokens  <- tokenVec[isSymbol]
   symbolModules <- moduleVec[isSymbol]
 
-  a <- matrix(FALSE, nrow = length(objectNames), ncol = length(moduleNames),
-              dimnames = list(objectNames, moduleNames))
+  objectsToModules <- matrix(FALSE, nrow = length(objectNames), ncol = length(moduleNames),
+                             dimnames = list(objectNames, moduleNames))
   if (length(symbolTokens) > 0) {
-    a[cbind(match(symbolTokens, objectNames),
-            match(symbolModules, moduleNames))] <- TRUE
+    objectsToModules[cbind(match(symbolTokens, objectNames),
+                           match(symbolModules, moduleNames))] <- TRUE
   }
 
   message("  Finished variable matching...         (time elapsed: ",
@@ -125,19 +125,19 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
 
   if (!is.null(x$not_used)) {
-    for (i in 1:dim(x$not_used)[1]) {
-      if (a[x$not_used[i, "name"], dimnames(x$not_used)[[1]][i]]) {
+    for (i in seq_len(dim(x$not_used)[1])) {
+      if (objectsToModules[x$not_used[i, "name"], dimnames(x$not_used)[[1]][i]]) {
         w <- .warning(x$not_used[i, "name"], " appears in not_used.txt of module ", dimnames(x$not_used)[[1]][i],
                       " but is used in the GAMS code of it!", w = w)
       }
-      a[x$not_used[i, "name"], dimnames(x$not_used)[[1]][i]] <- 2
+      objectsToModules[x$not_used[i, "name"], dimnames(x$not_used)[[1]][i]] <- 2
     }
   }
 
   sets <- x$declarations[x$declarations[, "type"] == "set", "names"]
-  aSets <- a[sets, , drop = FALSE]
-  a <- a[!(rownames(a) %in% sets), , drop = FALSE]
-  type <- sub("^(o|)[^_]*?(m|[0-9]{2}|)_.*$", "\\1\\2", dimnames(a)[[1]])
-  names(type) <- dimnames(a)[[1]]
-  return(list(appearance = a, setappearance = aSets, type = type, warnings = w))
+  aSets <- objectsToModules[sets, , drop = FALSE]
+  objectsToModules <- objectsToModules[!(rownames(objectsToModules) %in% sets), , drop = FALSE]
+  type <- sub("^(o|)[^_]*?(m|[0-9]{2}|)_.*$", "\\1\\2", dimnames(objectsToModules)[[1]])
+  names(type) <- dimnames(objectsToModules)[[1]]
+  return(list(appearance = objectsToModules, setappearance = aSets, type = type, warnings = w))
 }

--- a/R/checkAppearance.R
+++ b/R/checkAppearance.R
@@ -42,26 +42,16 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   tmp <- grep("execute_load", x$code, ignore.case = TRUE)
   x$code[tmp] <- gsub("=[^,]*", "", x$code[tmp])
 
-  tmp <- sapply(moduleNames, function(name, x) {
-    return(paste(x[names(x) == name], collapse = " "))
-  }, x$code)
-
   # add empty entry in tmp for module realization which do not contain any code but have a not_used.txt
-  notUsedNames <- unique(dimnames(x$not_used)[[1]])
-  missing <- notUsedNames[!(notUsedNames %in% moduleNames)]
+  modulesWithNotUsedFile <- unique(dimnames(x$not_used)[[1]])
+  missing <- modulesWithNotUsedFile[!(modulesWithNotUsedFile %in% moduleNames)]
   if (length(missing) > 0) {
-    mtmp <- rep("", length(missing))
-    names(mtmp) <- missing
-    tmp <- c(tmp, mtmp)
     moduleNames <- c(moduleNames, missing)
   }
 
   # Strip string literals so that variable names inside strings are not matched.
   # Both double-quoted and single-quoted GAMS strings are removed. The patterns use a
-  # negated character class (not a greedy ".*") so that each string literal is matched
-  # individually; a greedy match would span from the first to the last quote on a line and
-  # delete real tokens sitting between two separate strings (e.g. fm_croparea between two
-  # "y1995" literals).
+  # negated character class (not a greedy ".*").
   code <- x$code
   code <- gsub("\"[^\"]*\"", "", code)
   code <- gsub("'[^']*'", "", code)
@@ -76,7 +66,7 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   lineLengths   <- lengths(allTokenLists)
   tokenVec      <- unlist(allTokenLists, use.names = FALSE)
   lowerTokenVec <- tolower(tokenVec)
-  moduleVec     <- rep(names(x$code), lineLengths)
+  moduleVec     <- rep(names(code), lineLengths)
 
   # keep only non-empty tokens that are declared symbols
   isSymbol      <- nzchar(tokenVec) & (tokenVec %in% objectNames)

--- a/R/checkAppearance.R
+++ b/R/checkAppearance.R
@@ -24,16 +24,16 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   w <- NULL
   ptm <- proc.time()["elapsed"]
   message("  Running checkAppearance...")
-  colnames <- unique(names(x$code))
-  rownames <- unique(x$declarations[, "names"])
+  moduleNames <- unique(names(x$code))
+  objectNames <- unique(x$declarations[, "names"])
 
-  if (!is.null(x$not_used)) rownames <- unique(c(rownames, x$not_used[, "name"]))
+  if (!is.null(x$not_used)) objectNames <- unique(c(objectNames, x$not_used[, "name"]))
 
   # check for variables with different capitalization in declarations
-  if (length(rownames[duplicated(tolower(rownames))]) > 0) {
+  if (length(objectNames[duplicated(tolower(objectNames))]) > 0) {
     w <- .warning(paste0(
       "Found variables with more than one capitalization in declarations and not_used.txt files: ",
-      paste0(rownames[duplicated(tolower(rownames))], collapse = ", ")
+      paste0(objectNames[duplicated(tolower(objectNames))], collapse = ", ")
     ), w = w)
   }
 
@@ -43,21 +43,21 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   tmp <- grep("execute_load", x$code, ignore.case = TRUE)
   x$code[tmp] <- gsub("=[^,]*", "", x$code[tmp])
 
-  tmp <- sapply(colnames, function(name, x) {
+  tmp <- sapply(moduleNames, function(name, x) {
     return(paste(x[names(x) == name], collapse = " "))
   }, x$code)
 
   # add empty entry in tmp for module realization which do not contain any code but have a not_used.txt
   notUsedNames <- unique(dimnames(x$not_used)[[1]])
-  missing <- notUsedNames[!(notUsedNames %in% colnames)]
+  missing <- notUsedNames[!(notUsedNames %in% moduleNames)]
   if (length(missing) > 0) {
     mtmp <- rep("", length(missing))
     names(mtmp) <- missing
     tmp <- c(tmp, mtmp)
-    colnames <- c(colnames, missing)
+    moduleNames <- c(moduleNames, missing)
   }
 
-  declarationsRegex <- paste("(^|[^[:alnum:]_])", escapeRegex(rownames), "($|[^[:alnum:]_])", sep = "")
+  declarationsRegex <- paste("(^|[^[:alnum:]_])", escapeRegex(objectNames), "($|[^[:alnum:]_])", sep = "")
 
   message("  Start variable matching...            (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
@@ -71,8 +71,8 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   message("  Finished variable matching...         (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
 
-  dimnames(a)[[1]] <- rownames
-  dimnames(a)[[2]] <- colnames
+  dimnames(a)[[1]] <- objectNames
+  dimnames(a)[[2]] <- moduleNames
 
   # Find variables with different capitalization
 
@@ -95,9 +95,9 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
     return(length(chunks) != length(chunks[grepl(x, chunks, ignore.case = FALSE)]))
   })
 
-  if (length(rownames[setdiff(rownames[duplicates], capitalExclusionList)] > 0)) {
+  if (length(objectNames[setdiff(objectNames[duplicates], capitalExclusionList)] > 0)) {
 
-    duplicateNames <- unname(setdiff(rownames[duplicates], capitalExclusionList))
+    duplicateNames <- unname(setdiff(objectNames[duplicates], capitalExclusionList))
 
     msg <- paste0(
       "Found variables with more than one capitalization in the codebase: ",

--- a/R/checkAppearance.R
+++ b/R/checkAppearance.R
@@ -26,7 +26,6 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
   message("  Running checkAppearance...")
   moduleNames <- unique(names(x$code))
   objectNames <- unique(x$declarations[, "names"])
-
   if (!is.null(x$not_used)) objectNames <- unique(c(objectNames, x$not_used[, "name"]))
 
   # check for variables with different capitalization in declarations
@@ -57,43 +56,54 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
     moduleNames <- c(moduleNames, missing)
   }
 
-  declarationsRegex <- paste("(^|[^[:alnum:]_])", escapeRegex(objectNames), "($|[^[:alnum:]_])", sep = "")
+  # Strip string literals so that variable names inside strings are not matched.
+  # Both double-quoted and single-quoted GAMS strings are removed. The patterns use a
+  # negated character class (not a greedy ".*") so that each string literal is matched
+  # individually; a greedy match would span from the first to the last quote on a line and
+  # delete real tokens sitting between two separate strings (e.g. fm_croparea between two
+  # "y1995" literals).
+  code <- x$code
+  code <- gsub("\"[^\"]*\"", "", code)
+  code <- gsub("'[^']*'", "", code)
+  code <- gsub("display.*", "", code)
 
   message("  Start variable matching...            (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
 
-  # This part is the most time consuming (90% of the time in codeCheck). Here, the variable names are searched for in
-  # all module realizations. This process primarily seems to scale with the number of variables and not with the number
-  # of module realizations. It is hard to optimize since the number of variables that the code has to look for can
-  # hardly be reduced
-  a <- t(sapply(declarationsRegex, grepl, tmp, perl = TRUE))
+  # Tokenize all code lines at once and build an inverted (token -> module) index.
+  # This is O(code size) rather than O(symbols x code size), replacing the grepl sweep.
+  allTokenLists <- strsplit(code, "[^[:alnum:]_]+", perl = TRUE)
+  lineLengths   <- lengths(allTokenLists)
+  tokenVec      <- unlist(allTokenLists, use.names = FALSE)
+  lowerTokenVec <- tolower(tokenVec)
+  moduleVec     <- rep(names(x$code), lineLengths)
+
+  # keep only non-empty tokens that are declared symbols
+  isSymbol      <- nzchar(tokenVec) & (tokenVec %in% objectNames)
+  symbolTokens  <- tokenVec[isSymbol]
+  symbolModules <- moduleVec[isSymbol]
+
+  a <- matrix(FALSE, nrow = length(objectNames), ncol = length(moduleNames),
+              dimnames = list(objectNames, moduleNames))
+  if (length(symbolTokens) > 0) {
+    a[cbind(match(symbolTokens, objectNames),
+            match(symbolModules, moduleNames))] <- TRUE
+  }
 
   message("  Finished variable matching...         (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
 
-  dimnames(a)[[1]] <- objectNames
-  dimnames(a)[[2]] <- moduleNames
-
-  # Find variables with different capitalization
-
-  code <- x$code
-  # exclude \" comments \"
-  code <- gsub("\\\".*\\\"", "", code)
-  # exclude any text surrounded by with single quotes
-  code <- gsub("'.*'", "", code)
-  # exclude display statements
-  code <- gsub("display.*", "", code)
-
   message("  Start var capitalization check...     (time elapsed: ",
           format(proc.time()["elapsed"] - ptm, width = 6, nsmall = 2, digits = 2), ")")
 
-  # check for each variable if it appears with different capitalization in the code
-  duplicates <- sapply(declarationsRegex, function(x) {
-    # get all lines of code that match the variable (case insensitive)
-    chunks <- code[grepl(x, code, ignore.case = TRUE)]
-    # if case sensitive search yields less results, there must be occurrences different capitalization
-    return(length(chunks) != length(chunks[grepl(x, chunks, ignore.case = FALSE)]))
-  })
+  # Find symbols that appear with more than one capitalisation variant in the code.
+  # Uses the prebuilt token vector (O(tokens) build + O(1) per symbol lookup).
+  # tapply groups tokenVec by lowerTokenVec (its grouping key, same length) and counts the
+  # distinct casings within each group; any group with more than one casing is a duplicate.
+  casingCounts <- tapply(tokenVec, lowerTokenVec, function(v) length(unique(v)))
+  multiCaseSet <- names(casingCounts)[casingCounts > 1L]
+  duplicates   <- tolower(objectNames) %in% multiCaseSet
+  names(duplicates) <- objectNames
 
   if (length(objectNames[setdiff(objectNames[duplicates], capitalExclusionList)] > 0)) {
 
@@ -105,13 +115,18 @@ checkAppearance <- function(x, capitalExclusionList = NULL) {
     )
 
     for (dup in duplicateNames) {
-      msg <- paste0(msg, "- Lines found for item '", dup, "':\n")
-      dup <- paste("(^|[^[:alnum:]_])", escapeRegex(dup), "($|[^[:alnum:]_])", sep = "")
-      chunks <- code[grepl(dup, code, ignore.case = TRUE)]
-      msg <- paste0(msg, paste0(setdiff(chunks, chunks[grepl(dup, chunks, ignore.case = FALSE)]), collapse = "\n"))
+      msg <- paste0(msg, "- Suspicious lines found for item '", dup, "':\n")
+      dupRegex <- paste("(^|[^[:alnum:]_])", escapeRegex(dup), "($|[^[:alnum:]_])", sep = "")
+      chunks <- code[grepl(dupRegex, code, ignore.case = TRUE, perl = TRUE)]
+
+      tokens <- strsplit(chunks, "[^[:alnum:]_]+", perl = TRUE)
+      correctTokenCounts <- vapply(tokens, function(line) sum(dup == line), integer(1))
+      allTokenCounts <- vapply(tokens, function(line) sum(dup == tolower(line)), integer(1))
+      suspectLines <- chunks[correctTokenCounts != allTokenCounts]
+
+      msg <- paste0(msg, paste0(paste(" - ", suspectLines), collapse = "\n"))
       msg <- paste0(msg, "\n")
     }
-
     w <- .warning(msg, w = w)
 
   }

--- a/R/codeCheck.R
+++ b/R/codeCheck.R
@@ -331,7 +331,7 @@ codeCheck <- function(path = ".",
 
   # do interfaces appear only in not_used.txt files of a module?
   for (m in names(interfaceInfo)) {
-    r <- grep(paste("^", m, "(\\.|$)", sep = ""), dimnames(ap$appearance)[[2]])
+    r <- grep(paste0("^", m, "(\\.|$)"), dimnames(ap$appearance)[[2]])
     for (v in interfaceInfo[[m]]) {
       if (all(ap$appearance[v, r] != 1)) {
         interfacesOnlyNotused <- append(interfacesOnlyNotused, setNames(v, m))
@@ -342,7 +342,8 @@ codeCheck <- function(path = ".",
   if (length(interfacesOnlyNotused) > 0) {
     if (! isTRUE(interactive)) {
       w <- .warning(paste(unique(interfacesOnlyNotused), collapse = ", "),
-                    " was never declared, but exists only in not_used.txt of ",
+                    " is not used at all within each of the ",
+                    "following modules but listed in not_used.txt files these modules: ",
                     paste(unique(names(interfacesOnlyNotused)), collapse = ", "),
                     w = w)
     } else {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 'GAMS' Modularization Support Package
 
-R package **gms**, version **0.34.0**
+R package **gms**, version **0.35.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/gms)](https://cran.r-project.org/package=gms) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4390032.svg)](https://doi.org/10.5281/zenodo.4390032) [![R build status](https://github.com/pik-piam/gms/workflows/check/badge.svg)](https://github.com/pik-piam/gms/actions) [![codecov](https://codecov.io/gh/pik-piam/gms/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/gms) [![r-universe](https://pik-piam.r-universe.dev/badges/gms)](https://pik-piam.r-universe.dev/builds)
 
@@ -43,7 +43,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **gms** in publications use:
 
-Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2026). "gms: 'GAMS' Modularization Support Package." doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, Version: 0.34.0, <https://github.com/pik-piam/gms>.
+Dietrich J, Klein D, Giannousakis A, Beier F, Koch J, Baumstark L, Pflüger M, Richters O (2026). "gms: 'GAMS' Modularization Support Package." doi:10.5281/zenodo.4390032 <https://doi.org/10.5281/zenodo.4390032>, Version: 0.35.0, <https://github.com/pik-piam/gms>.
 
 A BibTeX entry for LaTeX users is
 
@@ -52,9 +52,9 @@ A BibTeX entry for LaTeX users is
   title = {gms: 'GAMS' Modularization Support Package},
   author = {Jan Philipp Dietrich and David Klein and Anastasis Giannousakis and Felicitas Beier and Johannes Koch and Lavinia Baumstark and Mika Pflüger and Oliver Richters},
   doi = {10.5281/zenodo.4390032},
-  date = {2026-06-18},
+  date = {2026-06-22},
   year = {2026},
   url = {https://github.com/pik-piam/gms},
-  note = {Version: 0.34.0},
+  note = {Version: 0.35.0},
 }
 ```

--- a/tests/testthat/test-checkAppearance.R
+++ b/tests/testthat/test-checkAppearance.R
@@ -148,6 +148,58 @@ test_that("checkAppearance detects a symbol located between two string literals 
   expect_true(result$appearance["f59_topsoilc_density", "fancymodule"])
 })
 
+makeNotUsed <- function(varNames, realization) {
+  matrix(varNames, ncol = 1,
+         dimnames = list(rep(realization, length(varNames)), "name"))
+}
+
+test_that("checkAppearance marks not_used variable as 2 when realization has no code", {
+  # "emptymod.default" has a not_used.txt listing vm_interface but zero code lines.
+  code <- c("vm_interface = 1;", "vm_interface = vm_interface + 1;")
+  names(code) <- c("core", "fancymod.default")
+
+  declarations <- matrix(
+    c("vm_interface", "", "", "variable"),
+    nrow = 1, ncol = 4, byrow = TRUE,
+    dimnames = list("core", c("names", "sets", "description", "type"))
+  )
+
+  x <- list(code = code, declarations = declarations,
+            not_used = makeNotUsed("vm_interface", "emptymod.default"))
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_true("emptymod.default" %in% colnames(result$appearance),
+              label = "realization with no code but not_used.txt must appear as a column")
+  expect_equal(result$appearance["vm_interface", "emptymod.default"], 2,
+               label = "variable listed in not_used.txt must have appearance value 2")
+  expect_null(result$warnings,
+              label = "no warning expected when not_used variable does not appear in code")
+})
+
+test_that("checkAppearance warns when a not_used variable actually appears in that realization's code", {
+  # "mod.default" lists vm_interface in not_used.txt but also uses it in its code.
+  code <- c("vm_interface = 1;", "vm_interface = vm_interface + 1;")
+  names(code) <- c("core", "mod.default")
+
+  declarations <- matrix(
+    c("vm_interface", "", "", "variable"),
+    nrow = 1, ncol = 4, byrow = TRUE,
+    dimnames = list("core", c("names", "sets", "description", "type"))
+  )
+
+  x <- list(code = code, declarations = declarations,
+            not_used = makeNotUsed("vm_interface", "mod.default"))
+
+  result <- suppressWarnings(suppressMessages(checkAppearance(x)))
+
+  notUsedConflictWarning <- any(grepl("appears in not_used", names(result$warnings)))
+  expect_true(notUsedConflictWarning,
+              label = "warning expected when not_used variable actually appears in the realization's code")
+  expect_equal(result$appearance["vm_interface", "mod.default"], 2,
+               label = "appearance value is still 2 even when there is a conflict")
+})
+
 test_that("checkAppearance still detects actual variable usage outside strings", {
   code <- c(
     "pm_corevar = 1;",

--- a/tests/testthat/test-checkAppearance.R
+++ b/tests/testthat/test-checkAppearance.R
@@ -111,21 +111,22 @@ test_that("checkAppearance does not warn when mixed casing is only inside string
                label = "casing difference inside a string literal must not trigger a warning")
 })
 
-test_that("checkAppearance ignores casing differences inside display statements", {
-  # display statements are stripped before tokenization, so a casing difference that
-  # only occurs inside a display statement must not be flagged.
+test_that("checkAppearance detects a variable that appears only in a display statement", {
+  # Regression for REMIND: variables like `display vm_emiFgas.L;` or `display p50_test;`
+  # can be the sole reference to an interface variable in a module. The display strip must
+  # not affect appearance detection — only the capitalisation check.
   code <- c(
-    "vm_Example = 1;",
-    "display vm_example;"
+    "vm_interface = 1;",
+    "display vm_interface;"
   )
-  names(code) <- c("core", "core")
+  names(code) <- c("core", "fancymodule")
 
-  x <- makeMinimalX(code, "vm_Example", "variable")
+  x <- makeMinimalX(code, "vm_interface", "variable")
 
   result <- suppressMessages(checkAppearance(x))
 
-  expect_false(hasCapWarning(result, "vm_Example"),
-               label = "casing difference inside a display statement must not trigger a warning")
+  expect_true(result$appearance["vm_interface", "fancymodule"],
+              label = "variable referenced only via display must still appear in that module")
 })
 
 test_that("checkAppearance detects a symbol located between two string literals on one line", {

--- a/tests/testthat/test-checkAppearance.R
+++ b/tests/testthat/test-checkAppearance.R
@@ -1,0 +1,167 @@
+makeMinimalX <- function(code, varNames, varTypes = NULL) {
+  if (is.null(varTypes)) varTypes <- rep("variable", length(varNames))
+  declarations <- matrix(
+    c(varNames, rep("", length(varNames)), rep("", length(varNames)), varTypes),
+    nrow = length(varNames), ncol = 4,
+    dimnames = list(rep("core", length(varNames)), c("names", "sets", "description", "type"))
+  )
+  list(code = code, declarations = declarations, not_used = NULL)
+}
+
+test_that("checkAppearance does not match variable names inside double-quoted strings", {
+  code <- c(
+    "pm_corevar = 1;",
+    "display \"vm_modulevar is used in module\";",
+    "vm_modulevar = pm_corevar;"
+  )
+  names(code) <- c("core", "core", "fancymodule")
+
+  x <- makeMinimalX(code, c("pm_corevar", "vm_modulevar"),
+                    c("parameter", "variable"))
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_false(result$appearance["vm_modulevar", "core"],
+               label = "vm_modulevar must not appear in core (only inside double-quoted string)")
+  expect_true(result$appearance["vm_modulevar", "fancymodule"])
+  expect_true(result$appearance["pm_corevar", "core"])
+  expect_true(result$appearance["pm_corevar", "fancymodule"])
+})
+
+test_that("checkAppearance does not match variable names inside single-quoted strings", {
+  code <- c(
+    "pm_corevar = 1;",
+    "pm_corevar.l = 'vm_modulevar is here';",
+    "vm_modulevar = pm_corevar;"
+  )
+  names(code) <- c("core", "core", "fancymodule")
+
+  x <- makeMinimalX(code, c("pm_corevar", "vm_modulevar"),
+                    c("parameter", "variable"))
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_false(result$appearance["vm_modulevar", "core"],
+               label = "vm_modulevar must not appear in core (only inside single-quoted string)")
+  expect_true(result$appearance["vm_modulevar", "fancymodule"])
+})
+
+hasCapWarning <- function(result, varName) {
+  any(grepl(paste0("capitalization.*", varName, "|", varName, ".*capitalization"), names(result$warnings)))
+}
+
+test_that("checkAppearance warns when a symbol appears with inconsistent capitalisation", {
+  code <- c(
+    "vm_Example = 1;",
+    "vm_example = 2;"
+  )
+  names(code) <- c("core", "fancymodule")
+
+  x <- makeMinimalX(code, "vm_Example", "variable")
+
+  result <- suppressWarnings(suppressMessages(checkAppearance(x)))
+
+  expect_true(hasCapWarning(result, "vm_Example"),
+              label = "capitalization warning expected for vm_Example")
+})
+
+test_that("checkAppearance does not warn when capitalisation is consistent", {
+  code <- c(
+    "vm_Example = 1;",
+    "vm_Example = 2;"
+  )
+  names(code) <- c("core", "fancymodule")
+
+  x <- makeMinimalX(code, "vm_Example", "variable")
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_false(hasCapWarning(result, "vm_Example"),
+               label = "no capitalization warning expected when casing is consistent")
+})
+
+test_that("checkAppearance does not warn for symbols in capitalExclusionList", {
+  code <- c(
+    "vm_Example = 1;",
+    "vm_example = 2;"
+  )
+  names(code) <- c("core", "fancymodule")
+
+  x <- makeMinimalX(code, "vm_Example", "variable")
+
+  result <- suppressMessages(checkAppearance(x, capitalExclusionList = "vm_Example"))
+
+  expect_false(hasCapWarning(result, "vm_Example"),
+               label = "excluded symbol must not produce a capitalization warning")
+})
+
+test_that("checkAppearance does not warn when mixed casing is only inside string literals", {
+  code <- c(
+    "vm_Example = 1;",
+    "pm_corevar = 'vm_example is just a label';"
+  )
+  names(code) <- c("core", "core")
+
+  x <- makeMinimalX(code, c("vm_Example", "pm_corevar"),
+                    c("variable", "parameter"))
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_false(hasCapWarning(result, "vm_Example"),
+               label = "casing difference inside a string literal must not trigger a warning")
+})
+
+test_that("checkAppearance ignores casing differences inside display statements", {
+  # display statements are stripped before tokenization, so a casing difference that
+  # only occurs inside a display statement must not be flagged.
+  code <- c(
+    "vm_Example = 1;",
+    "display vm_example;"
+  )
+  names(code) <- c("core", "core")
+
+  x <- makeMinimalX(code, "vm_Example", "variable")
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_false(hasCapWarning(result, "vm_Example"),
+               label = "casing difference inside a display statement must not trigger a warning")
+})
+
+test_that("checkAppearance detects a symbol located between two string literals on one line", {
+  # Regression test: a greedy string-stripping regex (".*") would match from the first
+  # quote to the last quote on the line and delete the real token (fm_croparea) sitting
+  # between the two "y1995" string literals. String literals must be stripped individually.
+  code <- c(
+    "pm_corevar = 1;",
+    "  pm_corevar = f59_topsoilc_density(\"y1995\",j) * fm_croparea(\"y1995\",j,w,kcr);"
+  )
+  names(code) <- c("core", "fancymodule")
+
+  x <- makeMinimalX(code, c("pm_corevar", "fm_croparea", "f59_topsoilc_density"),
+                    c("parameter", "parameter", "parameter"))
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_true(result$appearance["fm_croparea", "fancymodule"],
+              label = "fm_croparea sits between two string literals and must still be detected")
+  expect_true(result$appearance["f59_topsoilc_density", "fancymodule"])
+})
+
+test_that("checkAppearance still detects actual variable usage outside strings", {
+  code <- c(
+    "pm_corevar = 1;",
+    "vm_modulevar = pm_corevar;"
+  )
+  names(code) <- c("core", "fancymodule")
+
+  x <- makeMinimalX(code, c("pm_corevar", "vm_modulevar"),
+                    c("parameter", "variable"))
+
+  result <- suppressMessages(checkAppearance(x))
+
+  expect_true(result$appearance["pm_corevar", "core"])
+  expect_true(result$appearance["pm_corevar", "fancymodule"])
+  expect_false(result$appearance["vm_modulevar", "core"])
+  expect_true(result$appearance["vm_modulevar", "fancymodule"])
+})

--- a/tests/testthat/test-codeCheck.R
+++ b/tests/testthat/test-codeCheck.R
@@ -29,10 +29,10 @@ test_that(".checkAppearanceUsage produces warnings", {
                                                "mod.two")))
 
   ap <- list(type = apType,
-            appearance = apAppearance)
+             appearance = apAppearance)
 
   modulesInfo <- structure(c("mod", "10",
-                            "10_mod", "one,two"),
+                             "10_mod", "one,two"),
                           .Dim = c(1L, 4L),
                           .Dimnames = list(c("mod"),
                                            c("name", "number", "folder", "realizations")))


### PR DESCRIPTION
This PR primarily aims to make codeCheck faster. For MAgPIE it reduces the runtime from several minutes to about 10 seconds. The primary change is a switch from a regex that is executed per variable to a basic tokenization regex which is only applied once and then the rest of the check uses the token lists.

In the course of this change, this also solves a subtle bug. Before, the capitalization check worked by comparing the counts of regex matches for declared name with its original casing vs the name used with any casing. This check threw a warning if there were more uses with any casing, as this indicated that there were other casings than the original one. This however fails if the different casing is on the same line.

Additionally, this PR removes strings and display statements from the object names to modules table, which makes downstream checks more precise (e.g. as the mentioning of a variable in an explanatory text does not count as usage anymore).

Due to the different creation of the objects to modules table, the creation of the empty entries in `tmp` (old lines 46 - 58) are not needed anymore.